### PR TITLE
New web-money block for K-54

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -174,6 +174,7 @@ import { AudioPlayerBlockComponent } from './blocks/audio-player-block/audio-pla
 import { PlayerBlockComponent } from './blocks/player-block/player-block.component';
 import { BlockMultiBuilderBoxComponent } from './components/block-multi-builder-box/block-multi-builder-box.component';
 import { DurationPipe } from './pipes/duration.pipe';
+import { WebMoneyComponent } from './blocks/web-money/web-money.component';
 
 // AoT requires an exported function for factories
 export function HttpLoaderFactory(http: HttpClient) {
@@ -324,7 +325,8 @@ export function HttpLoaderFactory(http: HttpClient) {
     AudioPlayerBlockComponent,
     PlayerBlockComponent,
     BlockMultiBuilderBoxComponent,
-    DurationPipe
+    DurationPipe,
+    WebMoneyComponent
   ],
   imports: [
     FormlyModule.forRoot({}),

--- a/src/app/blocks/web-money/web-money.component.html
+++ b/src/app/blocks/web-money/web-money.component.html
@@ -1,0 +1,2 @@
+<p>💸 Web Monotization</p>
+<p *ngIf="!!paymentPointer && paymentPointer.length > 0">{{ paymentPointer }}</p>

--- a/src/app/blocks/web-money/web-money.component.ts
+++ b/src/app/blocks/web-money/web-money.component.ts
@@ -1,0 +1,44 @@
+import { Component } from '@angular/core';
+import { BaseBlockComponent } from '../base-block/base-block.component';
+import { mappingUtility } from '../mapping-block/mapping-util';
+import { get } from 'lodash-es';
+
+const metaSelector = 'meta[name="monetization"]';
+
+function setPaymentPointer(paymentPointer: string) {
+  // Creates or modifies monetization meta tag with a payment pointer
+  // using track data, stored in the player's dataset
+  var metaTag = document.querySelector(metaSelector);
+  if (!metaTag) {
+    metaTag = document.createElement('meta');
+    metaTag.setAttribute("name", "monetization");
+    document.head.appendChild(metaTag);
+    console.info('Added Web Monetization metatag for Web Money block')
+  }
+
+  metaTag.setAttribute("content", paymentPointer);
+  console.info('Set payment pointer to:', paymentPointer);
+}
+
+
+@Component({
+  selector: 'app-web-money-block',
+  templateUrl: './web-money.component.html',
+  styleUrls: ['./web-money.component.scss']
+})
+export class WebMoneyComponent extends BaseBlockComponent {
+
+  mapping = 'data.paymentPointer';
+  paymentPointer = '';
+
+
+  onConfigUpdate(config: any) {
+    this.mapping = get(config, 'mapping', this.mapping);
+  }
+
+  onData(data: any, _firstChange: boolean) {
+    this.paymentPointer = mappingUtility({ data: this.model, context: this.context }, this.mapping);
+    setPaymentPointer(this.model.paymentPointer);
+  }
+
+}

--- a/src/app/components/blocks-workflow/blocks-workflow.component.html
+++ b/src/app/components/blocks-workflow/blocks-workflow.component.html
@@ -50,6 +50,7 @@
     <app-xlsx-template-block class="block-wrapper" *ngSwitchCase="'xlsx-template'" [context]="context" [config]="block" [model]="models[i]" (output)="updateModel(i + 1, $event)"></app-xlsx-template-block>
     <app-validate-block class="block-wrapper" *ngSwitchCase="'validate'" [context]="context" [config]="block" [model]="models[i]" (output)="updateModel(i + 1, $event)"></app-validate-block>
     <app-audio-player-block class="block-wrapper" *ngSwitchCase="'player'" [context]="context" [config]="block" [model]="models[i]" (output)="updateModel(i + 1, $event)"></app-audio-player-block>
+    <app-web-money-block class="block-wrapper" *ngSwitchCase="'web-money'" [context]="context" [config]="block" [model]="models[i]" (output)="updateModel(i + 1, $event)"></app-web-money-block>
   </ng-container>
 </ng-container>
 <!-- <pre>workblock: {{ context | json }}</pre> -->


### PR DESCRIPTION
Adds a new 'web-money' block.
We might not actually want it in it's current form, but this is a starting point for review, so no rush for merging at all.

It can be used like this:
```javascript:
{
  "title": "Basic Player Web Money",
  "blocks": [
    {
      "type": "init"
    },
    {
      "type": "mapping",
      "mapping": "\n    {\n  \"display_artist\": 'Patient Pacifist',\n  \"display_title\": 'Green Juices',\n  \"url\": 'track.mp3',\n  \"paymentPointer\":'$ilp.example.com/some_payment_pointer}\n"
    },
    {
      "type": "player",
      "titleMapping": "data && data.join(' - ', [display_artist, display_title])",
      "onPlay": [
        {
          "type": "web-money"
        }
      ]
    }
  ],
  "id": "basicPlayerWebMoney",
  "adapterName": "examples"
}
```
Part of https://linear.app/kendraio/issue/K-54/demo-playing-a-track-and-tipping
