### PR TITLE
New web-money block for K-54

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -174,6 +174,7 @@ import { AudioPlayerBlockComponent } from './blocks/audio-player-block/audio-pla
 import { PlayerBlockComponent } from './blocks/player-block/player-block.component';
 import { BlockMultiBuilderBoxComponent } from './components/block-multi-builder-box/block-multi-builder-box.component';
 import { DurationPipe } from './pipes/duration.pipe';
+import { WebMoneyComponent } from './blocks/web-money/web-money.component';
 
 // AoT requires an exported function for factories
 export function HttpLoaderFactory(http: HttpClient) {
@@ -324,7 +325,8 @@ export function HttpLoaderFactory(http: HttpClient) {
     AudioPlayerBlockComponent,
     PlayerBlockComponent,
     BlockMultiBuilderBoxComponent,
-    DurationPipe
+    DurationPipe,
+    WebMoneyComponent
   ],
   imports: [
     FormlyModule.forRoot({}),

--- a/src/app/blocks/audio-player-block/audio-player-block.component.html
+++ b/src/app/blocks/audio-player-block/audio-player-block.component.html
@@ -20,12 +20,12 @@
                        [models]="[model]"
                        [context]="context"></app-blocks-workflow>
 </div>
-<div *ngIf="!hasError && onPlayBlocks.length > 0">
+<div *ngIf="!hasError && onPlayBlocks.length > 0 && isPlaying">
   <app-blocks-workflow [blocks]="onPlayBlocks"
                        [models]="[model]"
                        [context]="context"></app-blocks-workflow>
 </div>
-<div *ngIf="!hasError && onPauseBlocks.length > 0">
+<div *ngIf="isPlaying == false && onPauseBlocks.length > 0">
   <app-blocks-workflow [blocks]="onPauseBlocks"
                        [models]="[model]"
                        [context]="context"></app-blocks-workflow>

--- a/src/app/blocks/web-money/web-money.component.html
+++ b/src/app/blocks/web-money/web-money.component.html
@@ -1,0 +1,2 @@
+<p>💸 Web Monotization</p>
+<p *ngIf="!!paymentPointer && paymentPointer.length > 0">{{ paymentPointer }}</p>

--- a/src/app/blocks/web-money/web-money.component.html
+++ b/src/app/blocks/web-money/web-money.component.html
@@ -1,2 +1,4 @@
-<p>💸 Web Monotization</p>
-<p *ngIf="!!paymentPointer && paymentPointer.length > 0">{{ paymentPointer }}</p>
+<p>💸 Web Monetization</p>
+
+<p *ngIf="!!paymentPointer && enabled==true">{{ paymentPointer }}</p>
+<p *ngIf="enabled==false">Disabled</p>

--- a/src/app/blocks/web-money/web-money.component.ts
+++ b/src/app/blocks/web-money/web-money.component.ts
@@ -5,6 +5,7 @@ import { get } from 'lodash-es';
 
 const metaSelector = 'meta[name="monetization"]';
 
+
 function setPaymentPointer(paymentPointer: string) {
   // Creates or modifies monetization meta tag with a payment pointer
   // using track data, stored in the player's dataset
@@ -21,6 +22,15 @@ function setPaymentPointer(paymentPointer: string) {
 }
 
 
+function removePaymentPointer() {
+  console.info('removePaymentPointer called');
+  var metaTag = document.querySelector(metaSelector);
+  if (metaTag) {
+    metaTag.remove();
+  }
+};
+
+
 @Component({
   selector: 'app-web-money-block',
   templateUrl: './web-money.component.html',
@@ -30,15 +40,22 @@ export class WebMoneyComponent extends BaseBlockComponent {
 
   mapping = 'data.paymentPointer';
   paymentPointer = '';
-
+  enabled = true;
+  time: string = '';
 
   onConfigUpdate(config: any) {
-    this.mapping = get(config, 'mapping', this.mapping);
+    this.mapping = get(config, 'mapping', 'data.paymentPointer');
+    this.enabled = get(config, 'enabled', true);
   }
 
   onData(data: any, _firstChange: boolean) {
     this.paymentPointer = mappingUtility({ data: this.model, context: this.context }, this.mapping);
-    setPaymentPointer(this.model.paymentPointer);
+    if (!!this.model.paymentPointer && this.model.paymentPointer.length > 0 && this.enabled) {
+      setPaymentPointer(this.model.paymentPointer);
+    } else {
+      removePaymentPointer();
+    }
+
   }
 
 }

--- a/src/app/blocks/web-money/web-money.component.ts
+++ b/src/app/blocks/web-money/web-money.component.ts
@@ -1,0 +1,44 @@
+import { Component } from '@angular/core';
+import { BaseBlockComponent } from '../base-block/base-block.component';
+import { mappingUtility } from '../mapping-block/mapping-util';
+import { get } from 'lodash-es';
+
+const metaSelector = 'meta[name="monetization"]';
+
+function setPaymentPointer(paymentPointer: string) {
+  // Creates or modifies monetization meta tag with a payment pointer
+  // using track data, stored in the player's dataset
+  var metaTag = document.querySelector(metaSelector);
+  if (!metaTag) {
+    metaTag = document.createElement('meta');
+    metaTag.setAttribute("name", "monetization");
+    document.head.appendChild(metaTag);
+    console.info('Added Web Monetization metatag for Web Money block')
+  }
+
+  metaTag.setAttribute("content", paymentPointer);
+  console.info('Set payment pointer to:', paymentPointer);
+}
+
+
+@Component({
+  selector: 'app-web-money-block',
+  templateUrl: './web-money.component.html',
+  styleUrls: ['./web-money.component.scss']
+})
+export class WebMoneyComponent extends BaseBlockComponent {
+
+  mapping = 'data.paymentPointer';
+  paymentPointer = '';
+
+
+  onConfigUpdate(config: any) {
+    this.mapping = get(config, 'mapping', this.mapping);
+  }
+
+  onData(data: any, _firstChange: boolean) {
+    this.paymentPointer = mappingUtility({ data: this.model, context: this.context }, this.mapping);
+    setPaymentPointer(this.model.paymentPointer);
+  }
+
+}

--- a/src/app/blocks/web-money/web-money.component.ts
+++ b/src/app/blocks/web-money/web-money.component.ts
@@ -41,7 +41,6 @@ export class WebMoneyComponent extends BaseBlockComponent {
   mapping = 'data.paymentPointer';
   paymentPointer = '';
   enabled = true;
-  time: string = '';
 
   onConfigUpdate(config: any) {
     this.mapping = get(config, 'mapping', 'data.paymentPointer');

--- a/src/app/components/blocks-workflow/blocks-workflow.component.html
+++ b/src/app/components/blocks-workflow/blocks-workflow.component.html
@@ -50,6 +50,7 @@
     <app-xlsx-template-block class="block-wrapper" *ngSwitchCase="'xlsx-template'" [context]="context" [config]="block" [model]="models[i]" (output)="updateModel(i + 1, $event)"></app-xlsx-template-block>
     <app-validate-block class="block-wrapper" *ngSwitchCase="'validate'" [context]="context" [config]="block" [model]="models[i]" (output)="updateModel(i + 1, $event)"></app-validate-block>
     <app-audio-player-block class="block-wrapper" *ngSwitchCase="'player'" [context]="context" [config]="block" [model]="models[i]" (output)="updateModel(i + 1, $event)"></app-audio-player-block>
+    <app-web-money-block class="block-wrapper" *ngSwitchCase="'web-money'" [context]="context" [config]="block" [model]="models[i]" (output)="updateModel(i + 1, $event)"></app-web-money-block>
   </ng-container>
 </ng-container>
 <!-- <pre>workblock: {{ context | json }}</pre> -->


### PR DESCRIPTION
Adds a new 'web-money' block, and makes player pause and play "sub-block" events work properly.

It can be used like this:
```javascript:
{
  "title": "Basic Player Web Money",
  "blocks": [
    {
      "type": "init"
    },
    {
      "type": "mapping",
      "mapping": "\n    {\n  \"display_artist\": 'Artist name',\n  \"display_title\": 'Track title',\n  \"url\": 'track.mp3',\n  \"paymentPointer\":'$ilp.example.com/some_payment_pointer}\n"
    },
    {
      "type": "player",
      "titleMapping": "data && data.join(' - ', [display_artist, display_title])",
      "onPlay": [
        {
          "type": "web-money"
        }
      ],
      "onPause": [
        {
          "type": "web-money",
          "enabled": false
        }
      ]
    }
  ],
  "id": "basicPlayerWebMoney",
  "adapterName": "examples"
}
```
Part of https://linear.app/kendraio/issue/K-54/demo-playing-a-track-and-tipping
