### PR TITLE
K-60: 'Web money' support text

### DIFF
--- a/src/app/blocks/web-money/web-money.component.html
+++ b/src/app/blocks/web-money/web-money.component.html
@@ -1,10 +1,28 @@
-<p>💸 Web Monetization</p>
+<!-- 💸👌 Web Monetization compatibility detected -->
+<span *ngIf="supported == true">
 
-<p *ngIf="!!paymentPointer && enabled==true">{{ paymentPointer }}</p>
-<p *ngIf="enabled==false">Disabled</p>
-<div *ngIf="supported==true">
-    <app-template-block [config]=supportFoundTemplateConfig></app-template-block>
-</div>
-<div *ngIf="supported==false">
-    <app-template-block [config]=supportMissingTemplateConfig></app-template-block>
-</div>
+  <!-- 👍 Web Monetization working messaging -->
+  <app-template-block [config]="supportFoundTemplateConfig"></app-template-block>
+
+  <!-- 💸▶ active payment messaging -->
+  <span *ngIf="!!paymentPointer && enabled == true">
+    <app-template-block [config]="paymentActiveTemplateConfig"></app-template-block>
+
+    <!-- 🧐 show payment pointer for debugging etc -->
+    <span *ngIf="showPaymentPointer"> 
+        {{ paymentPointer }}
+    </span>
+  </span>
+
+  <!-- ⏸️ paused messaging -->
+  <span *ngIf="enabled == false">
+    <app-template-block [config]="paymentPausedTemplateConfig"></app-template-block>
+  </span> 
+
+</span>
+
+<!-- 💸😞😭 support not found -->
+<span *ngIf="supported == false">
+  <app-template-block [config]="supportMissingTemplateConfig"></app-template-block>
+</span>
+

--- a/src/app/blocks/web-money/web-money.component.html
+++ b/src/app/blocks/web-money/web-money.component.html
@@ -2,3 +2,9 @@
 
 <p *ngIf="!!paymentPointer && enabled==true">{{ paymentPointer }}</p>
 <p *ngIf="enabled==false">Disabled</p>
+<div *ngIf="supported==true">
+    <app-template-block [config]=supportFoundTemplateConfig></app-template-block>
+</div>
+<div *ngIf="supported==false">
+    <app-template-block [config]=supportMissingTemplateConfig></app-template-block>
+</div>

--- a/src/app/blocks/web-money/web-money.component.ts
+++ b/src/app/blocks/web-money/web-money.component.ts
@@ -5,6 +5,13 @@ import { get } from 'lodash-es';
 
 const metaSelector = 'meta[name="monetization"]';
 
+function isMonetizationSupported(): boolean {
+  if (!document['monetization']){
+    return false;
+  } else {
+    return true;
+  }
+}
 
 function setPaymentPointer(paymentPointer: string) {
   // Creates or modifies monetization meta tag with a payment pointer
@@ -41,10 +48,18 @@ export class WebMoneyComponent extends BaseBlockComponent {
   mapping = 'data.paymentPointer';
   paymentPointer = '';
   enabled = true;
-
+  supported = isMonetizationSupported();
+  supportFoundMessage = '';
+  supportMissingMessage = '';
+  supportFoundTemplateConfig = {template: this.supportFoundMessage};
+  supportMissingTemplateConfig = {template: this.supportMissingMessage};
+  
   onConfigUpdate(config: any) {
     this.mapping = get(config, 'mapping', 'data.paymentPointer');
     this.enabled = get(config, 'enabled', true);
+    this.supportFoundMessage = get(config, 'supportFoundMessage', 'It works!');
+    this.supportMissingMessage = get(config, 'supportMissingMessage', 'Install Coil?');
+    
   }
 
   onData(data: any, _firstChange: boolean) {
@@ -56,5 +71,7 @@ export class WebMoneyComponent extends BaseBlockComponent {
     }
 
   }
+
+
 
 }

--- a/src/app/blocks/web-money/web-money.component.ts
+++ b/src/app/blocks/web-money/web-money.component.ts
@@ -6,11 +6,7 @@ import { get } from 'lodash-es';
 const metaSelector = 'meta[name="monetization"]';
 
 function isMonetizationSupported(): boolean {
-  if (!document['monetization']){
-    return false;
-  } else {
-    return true;
-  }
+  return Boolean(document['monetization']);
 }
 
 function setPaymentPointer(paymentPointer: string) {
@@ -37,6 +33,21 @@ function removePaymentPointer() {
   }
 };
 
+const defaultPaymentActiveMessage = `💸▶️ Streaming web payment`;
+const defaultPaymentPausedMessage = '💸⏸️';
+const defaultSupportFoundMessage = '';
+const defaultSupportMissingMessage = `
+No Web Monetization support found 😟.
+<br> 
+<a href="https://webmonetization.org">
+  Learn about Web Monetization here.</a>
+<br>
+<br>
+<a href="https://coil.com">
+  <img src="https://coil.com/images/coil-logo.svg" title="Coil logo"/>
+  <br>
+  Support us with Coil.
+</a>`;
 
 @Component({
   selector: 'app-web-money-block',
@@ -49,17 +60,28 @@ export class WebMoneyComponent extends BaseBlockComponent {
   paymentPointer = '';
   enabled = true;
   supported = isMonetizationSupported();
-  supportFoundMessage = '';
-  supportMissingMessage = '';
-  supportFoundTemplateConfig = {template: this.supportFoundMessage};
-  supportMissingTemplateConfig = {template: this.supportMissingMessage};
-  
+  showPaymentPointer = true;
+  supportFoundMessage = defaultSupportFoundMessage;
+  supportMissingMessage = defaultSupportMissingMessage;
+  paymentActiveMessage = defaultPaymentActiveMessage;
+  paymentPausedMessage = defaultPaymentPausedMessage;
+  paymentActiveTemplateConfig = { template: this.paymentActiveMessage };
+  paymentPausedTemplateConfig = { template: this.paymentPausedMessage };
+  supportFoundTemplateConfig = { template: this.supportFoundMessage };
+  supportMissingTemplateConfig = { template: this.supportMissingMessage };
+
   onConfigUpdate(config: any) {
     this.mapping = get(config, 'mapping', 'data.paymentPointer');
     this.enabled = get(config, 'enabled', true);
-    this.supportFoundMessage = get(config, 'supportFoundMessage', 'It works!');
-    this.supportMissingMessage = get(config, 'supportMissingMessage', 'Install Coil?');
-    
+    this.showPaymentPointer = get(config, 'showPaymentPointer', true);
+    this.paymentPausedMessage = get(config, 'paymentPausedMessage', defaultPaymentPausedMessage);
+    this.supportFoundMessage = get(config, 'supportFoundMessage', defaultSupportFoundMessage);
+    this.supportMissingMessage = get(config, 'supportMissingMessage', defaultSupportMissingMessage);
+    this.paymentActiveTemplateConfig = { template: this.paymentActiveMessage };
+    this.paymentPausedTemplateConfig = { template: this.paymentPausedMessage };
+    this.supportFoundTemplateConfig = { template: this.supportFoundMessage };
+    this.supportMissingTemplateConfig = { template: this.supportMissingMessage };
+
   }
 
   onData(data: any, _firstChange: boolean) {
@@ -71,7 +93,5 @@ export class WebMoneyComponent extends BaseBlockComponent {
     }
 
   }
-
-
 
 }


### PR DESCRIPTION
Detects Web Monetization support and allows custom messaging for:
- support found
- support missing
- active payment
- paused payment

I added some default messaging.

I made it so the payment pointer visibility could be configured.

Default no support messaging:
![no_coil_etc](https://user-images.githubusercontent.com/306671/105507790-8a15e180-5cc3-11eb-872d-f1503ada91be.jpg)

Default success (demo gif):
![kendra-playing-money-2021-01-22](https://user-images.githubusercontent.com/306671/105508408-3a83e580-5cc4-11eb-86df-080719bbfb1a.gif)

https://linear.app/kendraio/issue/K-60/show-custom-messages-based-on-web-monetization-support