### PR TITLE
Player UI updates (K-98 / #167)

### DIFF
--- a/src/app/blocks/web-money/web-money.component.html
+++ b/src/app/blocks/web-money/web-money.component.html
@@ -10,7 +10,7 @@
 
     <!-- 🧐 show payment pointer for debugging etc -->
     <span *ngIf="showPaymentPointer"> 
-        {{ paymentPointer }}
+        Payment pointer: {{ paymentPointer }}
     </span>
   </span>
 

--- a/src/app/blocks/web-money/web-money.component.ts
+++ b/src/app/blocks/web-money/web-money.component.ts
@@ -164,6 +164,7 @@ export class WebMoneyComponent extends BaseBlockComponent {
     this.mapping = get(config, 'mapping', 'data.paymentPointer');
     this.enabled = get(config, 'enabled', true);
     this.showPaymentPointer = get(config, 'showPaymentPointer', true);
+    this.paymentActiveMessage = get(config, 'paymentActiveMessage', defaultPaymentActiveMessage);
     this.paymentPausedMessage = get(config, 'paymentPausedMessage', defaultPaymentPausedMessage);
     this.supportFoundMessage = get(config, 'supportFoundMessage', defaultSupportFoundMessage);
     this.supportMissingMessage = get(config, 'supportMissingMessage', defaultSupportMissingMessage);

--- a/src/app/components/waveform/waveform.component.html
+++ b/src/app/components/waveform/waveform.component.html
@@ -1,5 +1,5 @@
 <div class="time-display">
-  <div *ngIf="title" class="time-title">Now playing: {{title}}</div>
+  <div *ngIf="title" class="time-title">{{title}}</div>
   <div class="time-wide-space">
   </div>
   <div>{{currentTime|duration}}</div>


### PR DESCRIPTION
Adds header text "Payment pointer:" 
web-money block can now use the 'paymentActiveMessage' config.
Removes misleading "Now playing" text from Waveform (that would have displayed even when actually paused)
