### PR TITLE
Show latest payment stream amount  (K-101 / #170), documentation

### DIFF
--- a/docs/workflow/blocks/player.rst
+++ b/docs/workflow/blocks/player.rst
@@ -1,0 +1,29 @@
+Audio player
+============
+
+Play audio and with a waveform visual.
+Can be used with web-money - the Web Monetization block that allows streaming micropayments.
+
+Web Monetization example config:
+--------------
+
+.. code-block:: json
+    {
+        "type": "player",
+        "onPlay": [
+            {
+                "type": "web-money"
+            }
+        ],
+        "onPause": [
+            {
+                "type": "web-money",
+                "enabled": false
+            }
+        ]
+    }
+
+Required property
+--------------------
+
+Requires a ``url`` parameter string to an audio resource URL.

--- a/docs/workflow/blocks/web_money.rst
+++ b/docs/workflow/blocks/web_money.rst
@@ -1,0 +1,46 @@
+Web Money
+============
+
+Web Monetization block that allows streaming micropayments.
+Can be used with the Player block.
+
+Web Monetization example config:
+--------------
+
+.. code-block:: json
+    {
+        "type": "player",
+        "onPlay": [
+            {
+                "type": "web-money"
+            }
+        ],
+        "onPause": [
+            {
+                "type": "web-money",
+                "enabled": false
+            }
+        ]
+    }
+
+Data input
+--------------------
+
+To setup Web Monetization with a payment pointer, a ``paymentPointer`` property should be provided in data input.
+A non existant paymentPointer will remove any existing Web Monetization stream.
+
+Config
+--------------------
+
+showPaymentPointer
+showPaymentTotal
+fiatCurrency
+payTotalTitle
+paymentActiveMessage
+paymentPausedMessage
+supportFoundMessage
+supportMissingMessage
+paymentActiveMessage
+paymentPausedMessage
+supportFoundMessage
+supportMissingMessage

--- a/src/app/blocks/web-money/web-money.component.html
+++ b/src/app/blocks/web-money/web-money.component.html
@@ -12,7 +12,22 @@
     <span *ngIf="showPaymentPointer"> 
         Payment pointer: {{ paymentPointer }}
     </span>
-  </span>
+
+    <!-- 🧐 show payment stream total estimate -->
+    <div class="payTotal" *ngIf="showPaymentTotal && nativeTotalAmount"> 
+      <span class="payTitle">
+        {{payTotalTitle}}
+      </span>
+      <span class="nativeTotal"> 
+        {{ nativeTotalAmount }}
+      </span>
+      <span class="around"> 
+        ≈
+      </span>
+      <span class="fiatTotal" *ngIf="fiatTotalAmount"> 
+        {{ fiatTotalAmount }}
+      </span>
+    </div>
 
   <!-- ⏸️ paused messaging -->
   <span *ngIf="enabled == false">

--- a/src/app/blocks/web-money/web-money.component.html
+++ b/src/app/blocks/web-money/web-money.component.html
@@ -28,7 +28,8 @@
         {{ fiatTotalAmount }}
       </span>
     </div>
-
+  </span>
+  
   <!-- ⏸️ paused messaging -->
   <span *ngIf="enabled == false">
     <app-template-block [config]="paymentPausedTemplateConfig"></app-template-block>


### PR DESCRIPTION
Reveals the payment stream amounts to the end user, as a total of the native [crypto] currency amount for the current session, and estimates the value transferred in a fiat currency, to help the user understand the value exchange.

Adds a new 'fiatCurrency' configuration property that defaults to 'usd', but accepts 'eur', 'gbp' etc.

CoinGeck is used to estimate the amount with live market exchange rate data per session. 
They provide free access, and work without API keys, or server side code, across origins and I found a way to do it with a single request to avoid excess loading time of request chaining.

I've noticed only XRP in the native currency format so far when testing with Coil. 

![web_money_total_currency_estimate](https://user-images.githubusercontent.com/306671/110796704-285c0780-8270-11eb-9f89-9eee4788d485.gif)

I've also added basic documentation for the Web Money block and Player block.