### PR TITLE
K-108 / #175 - Tracking play statistics

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10898,6 +10898,11 @@
       "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
       "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
     },
+    "json-to-graphql-query": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/json-to-graphql-query/-/json-to-graphql-query-2.0.0.tgz",
+      "integrity": "sha512-+oFKHOVymP+jDETuLCl+ich+F7b8ym0vdczmOs8aJbtRd61+YGugVrtrI4xh5zfY1ZAVFG+zTAAsfDS1t5+17g=="
+    },
     "json3": {
       "version": "3.3.3",
       "resolved": "https://registry.npmjs.org/json3/-/json3-3.3.3.tgz",

--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
     "json-formatter-js": "^2.2.1",
     "json-schema-faker": "^0.5.0-rc19",
     "json-stringify-safe": "^5.0.1",
+    "json-to-graphql-query": "^2.0.0",
     "leaflet": "^1.6.0",
     "leaflet.markercluster": "^1.4.1",
     "lodash-es": "^4.17.11",

--- a/src/app/blocks/web-money/tracking.ts
+++ b/src/app/blocks/web-money/tracking.ts
@@ -1,86 +1,84 @@
-import uuid from 'uuid'
-import { jsonToGraphQLQuery } from 'json-to-graphql-query'
-
+import uuid from 'uuid';
+import { jsonToGraphQLQuery } from 'json-to-graphql-query';
 
 export class Tracking {
-    sessionUUID = uuid.v4()
-    queue = []
-    hotQueue = []
-    queueWaitSeconds = 10 // seconds
-    fake = false
-    graphqlEndpoint = "https://star-grackle-36.hasura.app/v1/graphql"
+  sessionUUID = uuid.v4();
 
+  queue = [];
 
-    sendData(data) {
-        function makeGraphQLMutationQuery(data) {
-            return JSON.stringify({
-                "query": jsonToGraphQLQuery({
+  hotQueue = [];
 
-                    mutation: {
-                        insert_stats: {
-                            __args: {
-                                objects: data
-                            },
-                            "affected_rows": true
-                        }
+  queueWaitSeconds = 10; // seconds
 
-                    }
+  fake = false;
 
-                }, {
-                    pretty: true
-                }),
-                "variables": null
-            })
-        }
-        if (this.fake) {
-            return new Promise((resolve, reject) => {
-                setTimeout(() => {
-                    console.info(' pretending to send for session UUID: ' + this.sessionUUID)
-                    console.info(makeGraphQLMutationQuery(data))
-                    resolve(undefined)
-                }, 50)
-            })
-        } else {
-            return fetch(this.graphqlEndpoint, {
-                "method": "POST",
-                "headers": {
-                    "Accept": "*/*",
-                    "content-type": "application/json"
-                },
-                "body": makeGraphQLMutationQuery(data)
-            })
-        }
+  graphqlEndpoint = 'https://star-grackle-36.hasura.app/v1/graphql';
+
+  queueWorkerTimer = setInterval(() => {
+    if (this.queue.length === 0) {
+      return;
     }
+    const parentThis = this;
+    this.hotQueue = JSON.parse(JSON.stringify(this.queue)); // clone
+    this.queue = [];
+    this.sendData(this.hotQueue).then((_) => {
+      console.info('Success sending, emptying queue');
+      parentThis.hotQueue = [];
+    });
+  }, this.queueWaitSeconds * 1000);
 
-    queueWorkerTimer = setInterval(() => {
-        if (this.queue.length === 0) {
-            return
-        }
-        var parentThis = this
-        this.hotQueue = JSON.parse(JSON.stringify(this.queue)) // clone
-        this.queue = []
-        this.sendData(this.hotQueue).then((_) => {
-            console.info('Success sending, emptying queue')
-            parentThis.hotQueue = []
-        })
+  sendData(data) {
+    function makeGraphQLMutationQuery(data) {
+      return JSON.stringify({
+        query: jsonToGraphQLQuery({
 
-    }, this.queueWaitSeconds * 1000)
+          mutation: {
+            insert_stats: {
+              __args: {
+                objects: data,
+              },
+              affected_rows: true,
+            },
 
-    capture(providedData) {
-        const timestamp = Math.floor(Date.now() / 1000)
-        const defaultData = {
-            "session": this.sessionUUID,
-            "date": timestamp,
-            "data": null, //data permits arbitrary JSON,
-            "numericKey": null, // but could be a string e.g: "XRP" 
-            "numericValue": null, // but could be a numeric value e.g: 123.456789
-            "type": null, // but could be a string,
-            "analyticsRecipientID": null, // should be set to allow a recipient to access the analytics data
-            "analyticsItemUUID": null // can be set to query unique items (e.g: a music track UUID)
-        }
-        this.queue.push({ ...defaultData, ...providedData })
+          },
+
+        }, {
+          pretty: true,
+        }),
+        variables: null,
+      });
     }
+    if (this.fake) {
+      return new Promise((resolve, reject) => {
+        setTimeout(() => {
+          console.info(` pretending to send for session UUID: ${this.sessionUUID}`);
+          console.info(makeGraphQLMutationQuery(data));
+          resolve(undefined);
+        }, 50);
+      });
+    }
+    return fetch(this.graphqlEndpoint, {
+      method: 'POST',
+      headers: {
+        Accept: '*/*',
+        'content-type': 'application/json',
+      },
+      body: makeGraphQLMutationQuery(data),
+    });
+  }
 
-
-
+  capture(providedData) {
+    const timestamp = Math.floor(Date.now() / 1000);
+    const defaultData = {
+      session: this.sessionUUID,
+      date: timestamp,
+      data: null, // data permits arbitrary JSON,
+      numericKey: null, // but could be a string e.g: "XRP"
+      numericValue: null, // but could be a numeric value e.g: 123.456789
+      type: null, // but could be a string,
+      analyticsRecipientID: null, // should be set to allow a recipient to access the analytics data
+      analyticsItemUUID: null, // can be set to query unique items (e.g: a music track UUID)
+    };
+    this.queue.push({ ...defaultData, ...providedData });
+  }
 }

--- a/src/app/blocks/web-money/tracking.ts
+++ b/src/app/blocks/web-money/tracking.ts
@@ -1,0 +1,76 @@
+import uuid from 'uuid'
+import { jsonToGraphQLQuery } from 'json-to-graphql-query'
+
+export class Tracking {
+    sessionUUID = uuid.v4() // TODO: ensure this doesn't refresh between tracks
+    queue = []
+    hotQueue = []
+    queueWaitSeconds = 2 // seconds
+    fake = false
+
+
+    sendData(data) {
+        function makeGraphQLMutationQuery(data) {
+            return JSON.stringify({
+                "query": jsonToGraphQLQuery({
+
+                    mutation: {
+                        insert_stats: {
+                            __args: {
+                                objects: data
+                            },
+                            "affected_rows": true
+                        }
+
+                    }
+
+                }, {
+                    pretty: true
+                }),
+                "variables": null
+            })
+        }
+        if (this.fake) {
+            return new Promise((resolve, reject) => {
+                setTimeout(() => {
+                    console.log(' pretending to send for session UUID: ' + this.sessionUUID)
+                    console.log(makeGraphQLMutationQuery(data))
+                    resolve(undefined)
+                }, 50)
+            })
+        } else {
+            return fetch("https://star-grackle-36.hasura.app/v1/graphql", {
+                "method": "POST",
+                "headers": {
+                    "Accept": "*/*",
+                    "content-type": "application/json"
+                },
+                "body": makeGraphQLMutationQuery(data)
+            })
+        }
+    }
+
+    queueWorkerTimer = setInterval(() => {
+
+        if (this.queue.length === 0) {
+            return
+        }
+        var parentThis = this
+        this.hotQueue = JSON.parse(JSON.stringify(this.queue)) // clone
+        this.queue = []
+        this.sendData(this.hotQueue).then((_) => {
+            console.log('Success sending, emptying queue')
+            parentThis.hotQueue = []
+        })
+
+    }, this.queueWaitSeconds * 1000)
+
+    capture(data, analyticsRecipientID, analyticsItemUUID) {
+        const timestamp = Math.floor(Date.now() / 1000)
+        this.queue.push({ "date": timestamp, "data": data, "session": this.sessionUUID, "analyticsRecipientID": analyticsRecipientID, "analyticsItemUUID": analyticsItemUUID })
+        console.log('Queue length:' + this.queue.length)
+    }
+
+
+
+}

--- a/src/app/blocks/web-money/tracking.ts
+++ b/src/app/blocks/web-money/tracking.ts
@@ -35,8 +35,8 @@ export class Tracking {
         if (this.fake) {
             return new Promise((resolve, reject) => {
                 setTimeout(() => {
-                    console.log(' pretending to send for session UUID: ' + this.sessionUUID)
-                    console.log(makeGraphQLMutationQuery(data))
+                    console.info(' pretending to send for session UUID: ' + this.sessionUUID)
+                    console.info(makeGraphQLMutationQuery(data))
                     resolve(undefined)
                 }, 50)
             })
@@ -60,7 +60,7 @@ export class Tracking {
         this.hotQueue = JSON.parse(JSON.stringify(this.queue)) // clone
         this.queue = []
         this.sendData(this.hotQueue).then((_) => {
-            console.log('Success sending, emptying queue')
+            console.info('Success sending, emptying queue')
             parentThis.hotQueue = []
         })
 


### PR DESCRIPTION
A fairly generic tracking module is added that sends a Graphql instance data no more than once every 10 seconds.
It is used by Web Money when tracking is enabled via block config.

It may be tested by viewing the "player/all" flow.