### PR TITLE
Icons and text of blocks

### DIFF
--- a/src/app/components/blocks-editor/blocks-editor.component.html
+++ b/src/app/components/blocks-editor/blocks-editor.component.html
@@ -3,6 +3,7 @@
   <mat-expansion-panel *ngFor="let block of blocks; let i = index" cdkDrag>
     <mat-expansion-panel-header>
       <mat-icon class="drag-handle" cdkDragHandle>reorder</mat-icon>
+      <app-kendraio-icon [icon]="blockIcons[block.type]"></app-kendraio-icon>
       <span class="block-type-title">{{ block.type }}</span>
     </mat-expansion-panel-header>
 

--- a/src/app/components/blocks-editor/blocks-editor.component.scss
+++ b/src/app/components/blocks-editor/blocks-editor.component.scss
@@ -8,6 +8,22 @@
   cursor: move;
 }
 
+
+:host ::ng-deep {
+  mat-expansion-panel app-kendraio-icon {
+    width: 1em;
+    height: 1em;
+    margin-right: 0.5em;
+    margin-left: 0.5em;
+  }
+
+  mat-expansion-panel app-kendraio-icon mat-icon.material-icons {
+    font-size: 1.3em;
+    line-height: 1.3em;
+  }
+}
+
+
 @import '~@angular/material/theming';
 .mat-expansion-panel {
   user-select: none;

--- a/src/app/components/blocks-editor/blocks-editor.component.ts
+++ b/src/app/components/blocks-editor/blocks-editor.component.ts
@@ -1,9 +1,13 @@
 import {Component, EventEmitter, Input, OnInit, Output} from '@angular/core';
 import {AddBlockDialogComponent} from '../../dialogs/add-block-dialog/add-block-dialog.component';
+import {BLOCK_TYPES} from '../../dialogs/add-block-dialog/block-types';
 import {MatDialog} from '@angular/material';
 import {moveItemInArray} from '@angular/cdk/drag-drop';
 import {clone} from 'lodash-es';
 
+
+const _blockIcons = {};
+BLOCK_TYPES.forEach(element => _blockIcons[element.type]=element.icon||'?');
 @Component({
   selector: 'app-blocks-editor',
   templateUrl: './blocks-editor.component.html',
@@ -12,6 +16,7 @@ import {clone} from 'lodash-es';
 export class BlocksEditorComponent implements OnInit {
 
   @Input() blocks = [];
+  @Input() blockIcons =_blockIcons;
   @Output() blockUpdate = new EventEmitter();
 
   constructor(
@@ -42,7 +47,7 @@ export class BlocksEditorComponent implements OnInit {
 
   addBlock() {
     const dialogRef = this.dialog.open(AddBlockDialogComponent, {
-      width: '460px'
+      width: '65vw'
     });
     dialogRef.afterClosed().subscribe(newBlock => {
       if (!!newBlock) {

--- a/src/app/dialogs/add-block-dialog/add-block-dialog.component.html
+++ b/src/app/dialogs/add-block-dialog/add-block-dialog.component.html
@@ -9,6 +9,7 @@
               [color]="(selectedBlockType && selectedBlockType.type == b.type) ? 'primary' : undefined"
               (click)="setBlockType(b)">
         <app-kendraio-icon [icon]="b.icon"></app-kendraio-icon>
+        {{b.label}}
       </button>
     </ng-container>
   </div>

--- a/src/app/dialogs/add-block-dialog/add-block-dialog.component.scss
+++ b/src/app/dialogs/add-block-dialog/add-block-dialog.component.scss
@@ -9,3 +9,10 @@ mat-card {
   height: 150px;
   margin-bottom: 1em;
 }
+
+
+.mat-flat-button {
+  display: inline-block;
+  min-width: 12em;
+  height: 3em;
+}


### PR DESCRIPTION
Adds icons to the list of blocks in the workflow sidebar.
When adding a block task, you can now see text in the block modal without having to mouseover.