### PR TITLE
Limit CSP wildcards to connect and images

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -23,7 +23,7 @@
     "headers": [{
       "source": "**/*",
       "headers": [
-        {"key": "Content-Security-Policy", "value": "frame-ancestors 'none'; script-src 'self' 'unsafe-eval' cdn.coil.com www.google-analytics.com ajax.googleapis.com maps.googleapis.com youtube.com s.ytimg.com;"},
+        {"key": "Content-Security-Policy", "value": "default-src 'self'; script-src cdn.coil.com www.google-analytics.com ajax.googleapis.com maps.googleapis.com youtube.com s.ytimg.com 'self' 'unsafe-eval'; style-src https://fonts.googleapis.com https://fonts.gstatic.com 'self' 'unsafe-inline'; img-src *; frame-ancestors 'none'; connect-src *; frame-src ajax.googleapis.com maps.googleapis.com youtube.com s.ytimg.com; font-src 'unsafe-inline' data: https://fonts.googleapis.com https://fonts.gstatic.com 'self'; form-action 'self';"},
         {"key": "X-Frame-Options", "value": "DENY"},
         {"key": "X-XSS-Protection", "value": "1; mode=block"}
       ]


### PR DESCRIPTION
We still want to allow images from anywhere, and any connect-src cross domain requests but most other things are locked down.