### PR TITLE
Whitelist Angular onload style change script

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -27,7 +27,7 @@
     "headers": [{
       "source": "**/*",
       "headers": [
-        {"key": "Content-Security-Policy", "value": "default-src 'self'; script-src cdn.coil.com www.google-analytics.com ajax.googleapis.com maps.googleapis.com youtube.com s.ytimg.com 'self' 'unsafe-eval'; style-src https://fonts.googleapis.com https://fonts.gstatic.com 'self' 'unsafe-inline'; img-src *; frame-ancestors 'none'; connect-src *; frame-src ajax.googleapis.com maps.googleapis.com youtube.com s.ytimg.com; font-src 'unsafe-inline' data: https://fonts.googleapis.com https://fonts.gstatic.com 'self'; form-action 'self';"},
+        {"key": "Content-Security-Policy", "value": "default-src 'self'; script-src 'sha256-MhtPZXr7+LpJUY5qtMutB+qWfQtMaPccfe7QXtCcEYc=' cdn.coil.com www.google-analytics.com ajax.googleapis.com maps.googleapis.com youtube.com s.ytimg.com 'self' 'unsafe-eval'; style-src https://fonts.googleapis.com https://fonts.gstatic.com 'self' 'unsafe-inline'; img-src *; frame-ancestors 'none'; connect-src *; frame-src ajax.googleapis.com maps.googleapis.com youtube.com s.ytimg.com; font-src 'unsafe-inline' data: https://fonts.googleapis.com https://fonts.gstatic.com 'self'; form-action 'self';"},
         {"key": "X-Frame-Options", "value": "DENY"},
         {"key": "X-XSS-Protection", "value": "1; mode=block"}
       ]


### PR DESCRIPTION
A stylesheet aimed to set it's media type to all useragent types, rather than being print specific by doing this inline script after it loaded:
"this.media='all'"

It failed due to the Content-Security-Policy, but by hashing the inline script, and adding it to the allow list, I hope to remedy the issue and fix the CSS.