### PR TITLE
Angular CSP fix: disabling inline optimizations

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -104,7 +104,14 @@
                   "with": "src/environments/environment.prod.ts"
                 }
               ],
-              "optimization": true,
+              "optimization": {
+                "scripts": true,
+                "styles": {
+                  "minify": true,
+                  "inlineCritical": false
+                },
+                "fonts": true
+              },
               "outputHashing": "all",
               "sourceMap": false,
               "namedChunks": false,
@@ -131,7 +138,14 @@
                   "with": "src/environments/environment.dev.ts"
                 }
               ],
-              "optimization": true,
+              "optimization": {
+                "scripts": true,
+                "styles": {
+                  "minify": true,
+                  "inlineCritical": false
+                },
+                "fonts": true
+              },
               "outputHashing": "all",
               "sourceMap": false,
               "namedChunks": false,


### PR DESCRIPTION
Though the CSP issue seems resolved in Chrome and Firefox, Safari/WebKit says:`Refused to execute a script for an inline event handler because 'unsafe-inline' does not appear in the script-src ` and refuses to show the page correctly unless inline optimizations are turned off.
So this turns them off.