### PR TITLE
Removing incompatible changes from angular.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,5 @@ testem.log
 # System Files
 .DS_Store
 Thumbs.db
+
+.vercel

--- a/angular.json
+++ b/angular.json
@@ -9,7 +9,13 @@
       "projectType": "application",
       "prefix": "app",
       "schematics": {
-      },
+        "@schematics/angular:component": {
+          "style": "scss"
+        },
+        "@schematics/angular:application": {
+          "strict": true
+        }
+      },      
       "architect": {
         "build": {
           "builder": "@angular-devkit/build-angular:browser",

--- a/angular.json
+++ b/angular.json
@@ -9,50 +9,6 @@
       "projectType": "application",
       "prefix": "app",
       "schematics": {
-        "@ngrx/schematics:component": {
-          "styleext": "scss",
-          "spec": false
-        },
-        "@ngrx/schematics:class": {
-          "spec": false
-        },
-        "@ngrx/schematics:directive": {
-          "spec": false
-        },
-        "@ngrx/schematics:guard": {
-          "spec": false
-        },
-        "@ngrx/schematics:module": {
-          "spec": false
-        },
-        "@ngrx/schematics:pipe": {
-          "spec": false
-        },
-        "@ngrx/schematics:service": {
-          "spec": false
-        },
-        "@schematics/angular:component": {
-          "styleext": "scss",
-          "spec": false
-        },
-        "@schematics/angular:class": {
-          "spec": false
-        },
-        "@schematics/angular:directive": {
-          "spec": false
-        },
-        "@schematics/angular:guard": {
-          "spec": false
-        },
-        "@schematics/angular:module": {
-          "spec": false
-        },
-        "@schematics/angular:pipe": {
-          "spec": false
-        },
-        "@schematics/angular:service": {
-          "spec": false
-        }
       },
       "architect": {
         "build": {


### PR DESCRIPTION
This is the fix to enable the CLI to work again. It also re-enables the automatic creation of testing files. 

To test this change you can use these commands: 
 ` ng generate service services/test-service `
and 
`ng generate component blocks/test-block`

Both these should work, creating framework files. In the case of the component, a template .scss file should be created, not a .css file. 


Fixes #239