### PR TITLE
Grid EnabledGetter - Error: Cannot read properties of undefined

### DIFF
--- a/src/app/blocks/grid-block/grid-block.component.ts
+++ b/src/app/blocks/grid-block/grid-block.component.ts
@@ -60,6 +60,10 @@ export class GridBlockComponent implements OnInit, OnChanges {
     if (!!this.gridAngular && get(this.config, 'sizeColumnsToFit', true)) {
       setTimeout(() => {
         this.zone.run(() => {
+          /** I've attempted a number of approaches to this, but this is the only reliable one. 
+           * I cannot seem to properly detect whether or not the api object exists. gridAngular exists. Api is an object and it's not null. 
+           * But, when the sizeColumnsToFit runs, it's gone.
+            try..catch seems to be the safest bet. */
           try {
             this.gridAngular.api.sizeColumnsToFit();
           } catch (e) {

--- a/src/app/blocks/grid-block/grid-block.component.ts
+++ b/src/app/blocks/grid-block/grid-block.component.ts
@@ -60,7 +60,11 @@ export class GridBlockComponent implements OnInit, OnChanges {
     if (!!this.gridAngular && get(this.config, 'sizeColumnsToFit', true)) {
       setTimeout(() => {
         this.zone.run(() => {
-          this.gridAngular.api.sizeColumnsToFit();
+          try {
+            this.gridAngular.api.sizeColumnsToFit();
+          } catch (e) {
+            console.log(e);
+          }
         });
       }, 40);
     }


### PR DESCRIPTION
When the grid is disabled, it disappears from the DOM. Sometimes there is an event waiting, and this can no longer find the grid, and throws an error. 
