### PR TITLE
CI reliability fixes: expands timeouts duration, disables unused video capture #246

### DIFF
--- a/cypress.json
+++ b/cypress.json
@@ -16,5 +16,6 @@
   },
   "watchForFileChanges":false,
   "projectId": "ebzwp1",
-  "pageLoadTimeout": 200000
+  "pageLoadTimeout": 200000,
+  "defaultCommandTimeout": 30000
 }

--- a/cypress.json
+++ b/cypress.json
@@ -2,6 +2,7 @@
   "integrationFolder": "cypress/integration",
   "supportFile": false,
   "videosFolder": "cypress/videos",
+  "video":false,
   "screenshotsFolder": "cypress/screenshots",
   "pluginsFile": false,
   "fixturesFolder": "cypress/fixtures",

--- a/cypress.json
+++ b/cypress.json
@@ -15,5 +15,6 @@
      "json": true
   },
   "watchForFileChanges":false,
-  "projectId": "ebzwp1"
+  "projectId": "ebzwp1",
+  "pageLoadTimeout": 200000
 }

--- a/cypress/integration/context_and_state.ts
+++ b/cypress/integration/context_and_state.ts
@@ -11,7 +11,7 @@ describe('Kendraio context and state', () => {
        ).as('adapterConfig.json');
   });
 
-  it('should be posttible for a template block to access global state values', () => {
+  it('should be possible for a template block to access global state values', () => {
     loadFlowCode([     
       {
          "type":"template",

--- a/cypress/integration/spec.ts
+++ b/cypress/integration/spec.ts
@@ -28,7 +28,7 @@ describe('workspace-project App', () => {
 
     cy.contains(
       '3ab8d0cd-7b76-5741-8bc9-5725650dc435',
-      { timeout: 10000 }
+      { timeout: 30000 }
     );
 
   });
@@ -42,7 +42,8 @@ describe('workspace-project App', () => {
     cy.contains('settings');
     cy.get('mat-toolbar > button mat-icon').contains('settings').click();
     cy.get('app-workflow-sidenav').contains('delete_forever').click();
-    cy.get('app-workflow-sidenav').contains('Mapping').should('not.exist');
+    cy.get('app-workflow-sidenav').contains('Mapping',
+    { timeout: 20000 }).should('not.exist');
     cy.get('app-workflow-sidenav').contains('Add Task').click();
     cy.contains('Select Task');
     cy.get('mat-dialog-container').contains('Mapping').click();
@@ -64,7 +65,7 @@ describe('workspace-project App', () => {
     ).as('flowList.json');
 
     cy.visit('/workflowCloud/listWorkflows');
-    cy.contains('Made up flow A', { timeout: 10000 });
+    cy.contains('Made up flow A', { timeout: 30000 });
   });
 
 

--- a/cypress/integration/spec.ts
+++ b/cypress/integration/spec.ts
@@ -1,6 +1,9 @@
 import { loadFlowCode } from '../support/helper';
 // tslint:disable: quotemark
 
+
+const THIRTY_SECONDS = 30000;
+
 describe('workspace-project App', () => {
 
   beforeEach(() => {
@@ -28,7 +31,7 @@ describe('workspace-project App', () => {
 
     cy.contains(
       '3ab8d0cd-7b76-5741-8bc9-5725650dc435',
-      { timeout: 30000 }
+      { timeout: THIRTY_SECONDS }
     );
 
   });
@@ -43,7 +46,7 @@ describe('workspace-project App', () => {
     cy.get('mat-toolbar > button mat-icon').contains('settings').click();
     cy.get('app-workflow-sidenav').contains('delete_forever').click();
     cy.get('app-workflow-sidenav').contains('Mapping',
-    { timeout: 20000 }).should('not.exist');
+      { timeout: THIRTY_SECONDS }).should('not.exist');
     cy.get('app-workflow-sidenav').contains('Add Task').click();
     cy.contains('Select Task');
     cy.get('mat-dialog-container').contains('Mapping').click();
@@ -65,7 +68,7 @@ describe('workspace-project App', () => {
     ).as('flowList.json');
 
     cy.visit('/workflowCloud/listWorkflows');
-    cy.contains('Made up flow A', { timeout: 30000 });
+    cy.contains('Made up flow A', { timeout: THIRTY_SECONDS });
   });
 
 

--- a/cypress/integration/spec.ts
+++ b/cypress/integration/spec.ts
@@ -6,11 +6,14 @@ describe('workspace-project App', () => {
   beforeEach(() => {
     // Prevent external network request for adapter config
     cy.intercept('GET', 'https://kendraio.github.io/kendraio-adapter/config.json', {
-       fixture: 'adapterConfig.json' }
-       ).as('adapterConfig.json');
+      fixture: 'adapterConfig.json'
+    }
+    ).as('adapterConfig.json');
   });
 
+
   it('should assert the mapping block produces the expected UUID string output', () => {
+
     loadFlowCode([
       {
         "type": "mapping",
@@ -22,8 +25,14 @@ describe('workspace-project App', () => {
         "showContext": false
       }
     ]);
-    cy.contains('3ab8d0cd-7b76-5741-8bc9-5725650dc435', { timeout: 10000 });
+
+    cy.contains(
+      '3ab8d0cd-7b76-5741-8bc9-5725650dc435',
+      { timeout: 10000 }
+    );
+
   });
+
 
   it('should make new workflow with mapping block', () => {
     cy.visit('/');
@@ -41,18 +50,22 @@ describe('workspace-project App', () => {
     cy.get('app-workflow-sidenav').contains('Mapping');
   });
 
+
   it('should display welcome message', () => {
     cy.visit('/');
     cy.contains('Kendraio App');
   });
 
+
   it('should display saved workflows', () => {
     cy.intercept('GET', 'https://app.kendra.io/api', {
-      fixture: 'flowList.json' }
-      ).as('flowList.json');
-    
+      fixture: 'flowList.json'
+    }
+    ).as('flowList.json');
+
     cy.visit('/workflowCloud/listWorkflows');
     cy.contains('Made up flow A', { timeout: 10000 });
   });
+
 
 });

--- a/cypress/integration/spec.ts
+++ b/cypress/integration/spec.ts
@@ -2,8 +2,6 @@ import { loadFlowCode } from '../support/helper';
 // tslint:disable: quotemark
 
 
-const THIRTY_SECONDS = 30000;
-
 describe('workspace-project App', () => {
 
   beforeEach(() => {
@@ -30,8 +28,7 @@ describe('workspace-project App', () => {
     ]);
 
     cy.contains(
-      '3ab8d0cd-7b76-5741-8bc9-5725650dc435',
-      { timeout: THIRTY_SECONDS }
+      '3ab8d0cd-7b76-5741-8bc9-5725650dc435'
     );
 
   });
@@ -45,8 +42,7 @@ describe('workspace-project App', () => {
     cy.contains('settings');
     cy.get('mat-toolbar > button mat-icon').contains('settings').click();
     cy.get('app-workflow-sidenav').contains('delete_forever').click();
-    cy.get('app-workflow-sidenav').contains('Mapping',
-      { timeout: THIRTY_SECONDS }).should('not.exist');
+    cy.get('app-workflow-sidenav').contains('Mapping').should('not.exist');
     cy.get('app-workflow-sidenav').contains('Add Task').click();
     cy.contains('Select Task');
     cy.get('mat-dialog-container').contains('Mapping').click();
@@ -59,27 +55,27 @@ describe('workspace-project App', () => {
     loadFlowCode([
       {
         "type": "mapping",
-        "mapping": "`true`",        
+        "mapping": "`true`",
         "blockComment": "testingComment",
       }
     ]);
     cy.get('mat-toolbar > button mat-icon').contains('settings').click();
-    cy.get('app-workflow-sidenav').contains('testingComment').should('exist');    
-    cy.get('app-workflow-sidenav').contains('testingComment').click();        
-    cy.get('app-workflow-sidenav').contains('Block Comment');    
+    cy.get('app-workflow-sidenav').contains('testingComment').should('exist');
+    cy.get('app-workflow-sidenav').contains('testingComment').click();
+    cy.get('app-workflow-sidenav').contains('Block Comment');
   });
 
   it('should display the comment for a generic editor block', () => {
     loadFlowCode([
       {
-        "type": "template",                
+        "type": "template",
         "blockComment": "testingComment first line\nComment line2",
       }
     ]);
     cy.get('mat-toolbar > button mat-icon').contains('settings').click();
     cy.get('app-workflow-sidenav').contains('testingComment').should('exist');
     cy.get('app-workflow-sidenav').contains('line2').should('not.exist');
-    cy.get('app-workflow-sidenav').contains('testingComment').click();        
+    cy.get('app-workflow-sidenav').contains('testingComment').click();
   });
 
 
@@ -97,7 +93,7 @@ describe('workspace-project App', () => {
     ).as('flowList.json');
 
     cy.visit('/workflowCloud/listWorkflows');
-    cy.contains('Made up flow A', { timeout: THIRTY_SECONDS });
+    cy.contains('Made up flow A');
   });
 
 

--- a/src/app/blocks/mapping-block/mapping-util.spec.ts
+++ b/src/app/blocks/mapping-block/mapping-util.spec.ts
@@ -6,7 +6,11 @@ import { mappingUtility } from './mapping-util';
 describe('MappingUtil', () => {
 
     it('should return the same value as is set', () => {
-        expect(mappingUtility('', "uuid('test')")).toBe('3ab8d0cd-7b76-5741-8bc9-5725650dc435');
+        expect(
+            mappingUtility('', "uuid('test')")
+        ).toBe(
+            '3ab8d0cd-7b76-5741-8bc9-5725650dc435'
+        );
     });
 
 });


### PR DESCRIPTION
This PR fixes observed Cypress CI failures by:
- increasing the page load timeout, 
- increases the default Cypress command timeouts.
- disabling videos.