### PR TITLE
Update template block to allow rendered html to be accessible in a flow

### DIFF
--- a/cypress/integration/templates_and_export.ts
+++ b/cypress/integration/templates_and_export.ts
@@ -1,0 +1,73 @@
+import { loadFlowCode } from '../support/helper';
+// tslint:disable: quotemark
+/// <reference types="Cypress" />
+
+describe('Template blocks', () => {
+
+  beforeEach(() => {
+    // Prevent external network request for adapter config
+    cy.intercept('GET', 'https://kendraio.github.io/kendraio-adapter/config.json', {
+       fixture: 'adapterConfig.json' }
+       ).as('adapterConfig.json');
+  });
+
+  it('should render visible html', () => {
+    loadFlowCode([     
+      {
+        "type": "init"
+      },
+      {
+        "type": "mapping",
+        "mapping": "{\r\n    \"header\": `Header`,\r\n    \"content\": `Content`\r\n}",
+        "blockComment": ""
+      },
+      {
+        "type": "template",
+        "template": "<p>visible:{{data.header}}</p><p>visible:{{data.content}}</p>",
+        "blockComment": ""
+      },
+      {
+        "type": "template",
+        "template": "<p>invisible:{{data.header}}</p><p>invisible:{{data.content}}</p>",
+        "renderToScreen": false,
+        "blockComment": ""
+      },
+      {
+        "type": "debug",
+        "open":2
+      }
+    ]);
+    cy.get('.dynamic-content').contains('visible:Header').should("exist");
+    cy.get('.dynamic-content').contains('invisible:Header', { timeout: 100 }).should("not.exist");
+  
+  });
+
+  it('should render html to the flow if renderToData is true', () => {
+    loadFlowCode([     
+      {
+        "type": "init"
+      },
+      {
+        "type": "mapping",
+        "mapping": "{\r\n    \"header\": `Header`,\r\n    \"content\": `Content`\r\n}",
+        "blockComment": ""
+      },
+      {
+        "type": "template",
+        "template": "<p>invisible:{{data.header}}</p><p>invisible:{{data.content}}</p>",
+        "renderToScreen": false,
+        "key":"renderedHtml",
+       },
+      {
+        "type": "debug",
+        "open":2
+      }
+    ]);
+   
+    cy.get('.dynamic-content').contains('invisible:Header', { timeout: 100 }).should("not.exist");
+    cy.get('.model-output').contains('invisible:Header', { timeout: 100 }).should("exist");
+  });
+
+
+});
+

--- a/docs/workflow/blocks/template.rst
+++ b/docs/workflow/blocks/template.rst
@@ -1,7 +1,9 @@
 Template
 ========
 
-Display templated output based on current modal values.
+Render templated output based on current model values. Rendered HTML also will be added to the data model to be accessible in the flow. 
+
+All data is passed through a template block unmodified, with the rendered content available at "data.renderedHtml". 
 
 Default config
 --------------
@@ -10,8 +12,19 @@ Default config
 
     {
       "type": "template",
-      "template": ""
+      "template": ""       
     }
+
+Supported properties
+--------------------
+
+- **renderToScreen** - (default: true) Display rendered HTML in the browser. Set to false to hide rendered html
+- **key** - (default: "renderedHtml") Name of the data model property to store rendered HTML in.
+  
+
+
+More information
+----------------
 
 See the Handlebars documentation for full list of supported templating features.
 


### PR DESCRIPTION
This is a small update to the template block that will places the rendered html from a template block into the data model. This makes it possible to build flows that can export HTML. 