### PR TITLE
Auth0 Callback page now has default behaviour

### DIFF
--- a/cypress/integration/authentication.ts
+++ b/cypress/integration/authentication.ts
@@ -1,0 +1,11 @@
+import { loadFlowCode } from '../support/helper';
+// tslint:disable: quotemark
+/// <reference types="Cypress" />
+
+describe('Old Account page', () => {
+
+    it('the callback page should always redirect to /user', () => {
+        cy.visit('/callback');
+        cy.url().should('contain','/user');
+    });
+});

--- a/src/app/services/auth.service.ts
+++ b/src/app/services/auth.service.ts
@@ -50,7 +50,7 @@ export class AuthService {
 
   public handleAuthentication(): void {
     this.auth0.parseHash((err, authResult) => {
-      // console.log({ authResult });
+       console.log({ authResult });
       if (authResult && authResult.accessToken && authResult.idToken) {
         window.location.hash = '';
 
@@ -65,6 +65,9 @@ export class AuthService {
         this.router.navigate(['/user']);
       } else if (err) {
         console.log(err);
+        this.router.navigate(['/user']);
+      } else {
+        // if we get no auth data, redirect to old user page
         this.router.navigate(['/user']);
       }
     });

--- a/src/app/services/auth.service.ts
+++ b/src/app/services/auth.service.ts
@@ -50,7 +50,7 @@ export class AuthService {
 
   public handleAuthentication(): void {
     this.auth0.parseHash((err, authResult) => {
-       console.log({ authResult });
+      // console.log({ authResult });
       if (authResult && authResult.accessToken && authResult.idToken) {
         window.location.hash = '';
 


### PR DESCRIPTION
This update provides a simple additional behaviour for the auth0 callback page. If no authentication data is passed in the url, then the user is forwarded directly to the user page. A user should never be left on this page, and since this is an authentication callback, we can safely send users to the /user page. 

The Auth0 login process for Youtube seems to cause the callback page to be reloaded after authentication is complete. The second call is missing the authentication payload, and without any default action, we get stuck. 

I would like to find the source of the second redirect, but it has so far taken enough time, and may not be worth further investment. 

