### PR TITLE
Context documentation

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -44,6 +44,7 @@ Kendraio App
    workflow/blocks/card
    workflow/blocks/chart
    workflow/blocks/context_block
+   workflow/blocks/context_runner_block
    workflow/blocks/csv_export
    workflow/blocks/csv_import
    workflow/blocks/db

--- a/docs/workflow/blocks/context_block.rst
+++ b/docs/workflow/blocks/context_block.rst
@@ -116,8 +116,7 @@ There is currently no access control or protection in state. Any path in the glo
 In the future some form of restriction may be implemented. 
 
 
+See also
+--------
 
-
-
-
-
+- :ref:`context_runner_block` - The block that runs flows in their own context and then runs another seperate flow.

--- a/docs/workflow/blocks/context_runner_block.rst
+++ b/docs/workflow/blocks/context_runner_block.rst
@@ -68,6 +68,8 @@ In the below example, Dropbox uploads are listed. The contextBlocks sub-flow get
     ]
 
 
+The above example is from: https://app.kendra.io/dropbox/listUploads
+
 Config properties
 -----------------
 

--- a/docs/workflow/blocks/context_runner_block.rst
+++ b/docs/workflow/blocks/context_runner_block.rst
@@ -1,0 +1,82 @@
+Context Runner Block
+====================
+
+The Context block is a good way to run more complicated flows that depend on a value from an asynchronous source, like an API call or user input.
+
+The Context block accepts a list of blocks, contextBlocks, a contextPath and a list of blocks, blocks.
+
+The Context block is configured with two flows. The first flow, contextBlocks, is run first. Once the contextBlocks flow yields a result, the Context block runs the blocks flow, and blocks can load the value from the contextPath using a block like the Mapping block.
+
+In the below example, Dropbox uploads are listed. The contextBlocks sub-flow gets a token from a auth0 block, and the blocks sub-flow uses the token to perform an authenticated request to Dropbox's API, in this case, to list the users files from Dropbox.
+
+.. code-block:: json
+
+    [
+      {
+        "type": "init"
+      },
+      {
+        "type": "mapping",
+        "mapping": "{ path: '/uploads' }"
+      },
+      {
+        "type": "context",
+        "contextPath": "dropboxAuth",
+        "contextBlocks": [
+          {
+            "type": "auth0",
+            "provider": "dropbox"
+          }
+        ],
+        "blocks": [
+          {
+            "type": "debug",
+            "open": 0,
+            "showContext": true
+          },
+          {
+            "type": "http",
+            "method": "post",
+            "notify": false,
+            "endpoint": {
+              "protocol": "https:",
+              "host": "api.dropboxapi.com",
+              "pathname": "/2/files/list_folder"
+            },
+            "authentication": {
+              "type": "bearer",
+              "valueGetters": {
+                "jwt": "context.dropboxAuth.access_token"
+              }
+            }
+          }
+        ]
+      },
+      {
+        "type": "debug",
+        "open": 0,
+        "showContext": false
+      },
+      {
+        "type": "mapping",
+        "mapping": "data.entries"
+      },
+      {
+        "type": "grid",
+        "gridOptions": {}
+      }
+    ]
+
+
+Config properties
+-----------------
+
+- **contextBlocks**: A list of blocks to run first.
+- **contextPath**: The path to save the contextBlocks output to.
+- **blocks**: A list of blocks to run after the contextBlocks.
+- **skipFirst**: If true, the contextBlocks are not ran on the first data event.
+
+See also
+--------
+
+- :ref:`context_block` - the more simple block for saving data to a context or state path directly.

--- a/src/app/blocks/context-block/context-block.component.ts
+++ b/src/app/blocks/context-block/context-block.component.ts
@@ -27,6 +27,11 @@ export class ContextBlockComponent extends BaseBlockComponent {
   }
 
   onConfigUpdate(config: any) {
+    /**
+     * The Context block config accepts a list of blocks, contextBlocks, a contextPath
+     * The contextBlocks are ran first (until they produce output), once they output data, the data is saved to the contextPath
+     * The flows from the "blocks" config are then ran, and can access the contextPath value
+     */
     this.blocks = get(config, 'blocks', []);
     this.skipFirst = get(config, 'skipFirst', false);
     this.contextPath = get(config, 'contextPath', 'temp');
@@ -60,12 +65,19 @@ export class ContextBlockComponent extends BaseBlockComponent {
   }
 
   onContextComplete(value) {
+    /**
+     * Executes when the contextBlocks have produced an output, with a workflowComplete event
+     */
     this.contextOutput = value;
+    // setTimeout is used to run the flow after Angular has finished updating the DOM
     setTimeout(() => {
       this.zone.run(() => {
+        // The contextOutput is saved to the contextPath
         set(this.newContext, this.contextPath, this.contextOutput);
         this.gotContextValue = true;
+        // Now output has been saved to the contextPath, the blocks are ran
         this.models = [clone(this.model)];
+        // The blocks can access the contextPath value
       });
     }, 0);
   }


### PR DESCRIPTION
Comments the code in JSDoc style, adds new documentation as below, and adds links between the docs for the two context blocks.

Context Runner Block
====================

The Context block is a good way to run more complicated flows that depend on a value from an asynchronous source, like an API call or user input.

The Context block accepts a list of blocks, contextBlocks, a contextPath and a list of blocks, blocks.

The Context block is configured with two flows. The first flow, contextBlocks, is run first. Once the contextBlocks flow yields a result, the Context block runs the blocks flow, and blocks can load the value from the contextPath using a block like the Mapping block.

In the below example, Dropbox uploads are listed. The contextBlocks sub-flow gets a token from a auth0 block, and the blocks sub-flow uses the token to perform an authenticated request to Dropbox's API, in this case, to list the users files from Dropbox.

```json

    [
      {
        "type": "init"
      },
      {
        "type": "mapping",
        "mapping": "{ path: '/uploads' }"
      },
      {
        "type": "context",
        "contextPath": "dropboxAuth",
        "contextBlocks": [
          {
            "type": "auth0",
            "provider": "dropbox"
          }
        ],
        "blocks": [
          {
            "type": "debug",
            "open": 0,
            "showContext": true
          },
          {
            "type": "http",
            "method": "post",
            "notify": false,
            "endpoint": {
              "protocol": "https:",
              "host": "api.dropboxapi.com",
              "pathname": "/2/files/list_folder"
            },
            "authentication": {
              "type": "bearer",
              "valueGetters": {
                "jwt": "context.dropboxAuth.access_token"
              }
            }
          }
        ]
      },
      {
        "type": "debug",
        "open": 0,
        "showContext": false
      },
      {
        "type": "mapping",
        "mapping": "data.entries"
      },
      {
        "type": "grid",
        "gridOptions": {}
      }
    ]
```

The above example is from: https://app.kendra.io/dropbox/listUploads

Config properties
-----------------

- **contextBlocks**: A list of blocks to run first.
- **contextPath**: The path to save the contextBlocks output to.
- **blocks**: A list of blocks to run after the contextBlocks.
- **skipFirst**: If true, the contextBlocks are not ran on the first data event.

See also
--------

- :ref:`context_block` - the more simple block for saving data to a context or state path directly.
