### PR TITLE
 HTTP block pagination support

### DIFF
--- a/cypress/e2e/http_block_page_following.ts
+++ b/cypress/e2e/http_block_page_following.ts
@@ -1,0 +1,196 @@
+import { loadFlowCode } from '../support/helper';
+
+// tslint:disable: quotemark
+/// <reference types="Cypress" />
+
+describe('HTTP Block Integration Tests', () => {
+
+    beforeEach(() => {
+        // Prevent external network request for adapter config
+        cy.intercept('GET', 'https://kendraio.github.io/kendraio-adapter/config.json', {
+            fixture: 'adapterConfig.json'
+        });
+
+        // Prevent external network requests for Workflow cloud
+        cy.intercept('GET', 'https://app.kendra.io/api/workflowCloud/listWorkflows', {
+            fixture: 'workflow-cloud.json'
+        });
+
+        // Prevent external network requests for fonts with empty CSS rule 
+        cy.intercept('https://fonts.googleapis.com/\*\*', "\*{ }");
+    });
+
+
+    it('should follow pagination links and merge results without a proxy', () => {
+        // We emulate the CORS proxy presenting the first set of results,
+        // with a link header pointing to the next page.
+        cy.intercept({
+            url: 'https://example.com/paginated'
+        }, {
+            statusCode: 200,
+            body: '["cats","dogs"]',
+            headers: {
+                'link': '<https://example.com/paginated&page=2>; rel="next"',
+            }
+        });
+
+        // If the target URL is for the second page, we return the second set of results:
+        cy.intercept({
+            url: 'https://example.com/paginated&page=2'
+        }, {
+            statusCode: 200,
+            body: '["fish","birds"]',
+            headers: {
+                'link': '<https://example.com/paginated>; rel="prev"',
+            }
+        });
+
+        // We test page following by setting the "followPaginationLinksMerged" flag:
+        loadFlowCode([
+            { "type": "init" },
+            {
+                "type": "http",
+                "method": "GET",
+                "endpoint": "https://example.com/paginated",
+                "useProxy": false,
+                "followPaginationLinksMerged": true,
+            },
+            {
+                "type": "debug",
+                "open": 2,
+                "showData": true
+            }
+        ]);
+        cy.contains('cats');
+        cy.contains('dogs');
+        cy.contains('fish');
+        cy.contains('birds');
+    });
+
+    it('should follow pagination links and merge results using a proxy', () => {
+        // We emulate the CORS proxy presenting the first set of results,
+        // with a link header pointing to the next page.
+        cy.intercept({
+            url: 'https://proxy.kendra.io/',
+            headers: {
+                'Target-URL': 'https://example.com/paginated',
+            }
+        }, {
+            statusCode: 200,
+            body: '["cats","dogs"]',
+            headers: {
+                'link': '<https://example.com/paginated&page=2>; rel="next"',
+            }
+        });
+
+        // If the target URL is for the second page, we return the second set of results:
+        cy.intercept({
+            url: 'https://proxy.kendra.io/',
+            headers: {
+                'Target-URL': 'https://example.com/paginated&page=2',
+            },
+        }, {
+            statusCode: 200,
+            body: '["fish","birds"]',
+            headers: {
+                'link': '<https://example.com/paginated>; rel="prev"',
+            }
+        });
+
+        // We test page following by setting the "followPaginationLinksMerged" flag:
+        loadFlowCode([
+            { "type": "init" },
+            {
+                "type": "http",
+                "method": "GET",
+                "endpoint": "https://example.com/paginated",
+                "useProxy": true,
+                "followPaginationLinksMerged": true,
+            },
+            {
+                "type": "debug",
+                "open": 2,
+                "showData": true
+            }
+        ]);
+        cy.contains('cats');
+        cy.contains('dogs');
+        cy.contains('fish');
+        cy.contains('birds');
+    });
+
+    it('should return a single set of results if response is not paginated', () => {
+        cy.intercept({
+            url: 'https://example.com/data'
+        }, {
+            statusCode: 200,
+            body: '["hippo", "giraffe"]'
+        });
+
+        loadFlowCode([
+            { "type": "init" },
+            {
+                "type": "http",
+                "method": "GET",
+                "endpoint": "https://example.com/data"
+            },
+            {
+                "type": "debug",
+                "open": 2,
+                "showData": true
+            }
+        ]);
+        cy.contains('hippo');
+        cy.contains('giraffe');
+    });
+
+    it('should return first results only if not paginated, with proxy', () => {
+        cy.intercept({
+            url: 'https://proxy.kendra.io/',
+            headers: {
+                'Target-URL': 'https://example.com/paginated',
+            }
+        }, {
+            statusCode: 200,
+            body: '["cats","dogs"]',
+            headers: {
+                'link': '<https://example.com/paginated&page=2>; rel="next"',
+            }
+        });
+
+        // We do not expect this to be called:
+        cy.intercept({
+            url: 'https://proxy.kendra.io/',
+            headers: {
+                'Target-URL': 'https://example.com/paginated&page=2',
+            },
+        }, {
+            statusCode: 200,
+            body: '["fish","birds"]',
+            headers: {
+                'link': '<https://example.com/paginated>; rel="prev"',
+            }
+        }).as('secondPage');
+
+        loadFlowCode([
+            { "type": "init" },
+            {
+                "type": "http",
+                "method": "GET",
+                "endpoint": "https://example.com/paginated",
+                "useProxy": true
+            },
+            {
+                "type": "debug",
+                "open": 2,
+                "showData": true
+            }
+        ]);
+        cy.contains('cats');
+        cy.contains('dogs');
+        // we check it does not contain a second page result:
+        cy.get('body').should('not.contain', 'fish');
+    });
+
+
+});

--- a/docs/workflow/blocks/http.rst
+++ b/docs/workflow/blocks/http.rst
@@ -100,3 +100,18 @@ It is possible to query a GraphQL endpoint using the HTTP block.
   }
 
 
+Pagination
+----------
+
+If a HTTP API returns paginated results with a standard link header, to fetch paginated API results, set the followPaginationLinksMerged option to true. This will fetch all pages of results and return the combined set of results from all the pages.
+
+With a proxy:
+```json
+{
+  "type": "http",
+  "method": "GET",
+  "endpoint": "https://example.com/paginated",
+  "useProxy": true,
+  "followPaginationLinksMerged": true
+}
+```

--- a/src/app/blocks/http-block/http-block.component.spec.ts
+++ b/src/app/blocks/http-block/http-block.component.spec.ts
@@ -1,0 +1,37 @@
+import { HttpBlockComponent } from './http-block.component';
+import { ContextDataService } from '../../services/context-data.service';
+import { MatLegacySnackBar as MatSnackBar } from '@angular/material/legacy-snack-bar';
+import { HttpClient } from '@angular/common/http';
+
+describe('extractNextPageUrl', () => {
+    let component: HttpBlockComponent;
+    let contextDataServiceMock: ContextDataService;
+    let httpClientMock: HttpClient;
+    let matSnackBarMock: MatSnackBar;
+
+    beforeEach(() => {
+        contextDataServiceMock = jasmine.createSpyObj('ContextDataService', ['getGlobalContext']);
+        httpClientMock = jasmine.createSpyObj('HttpClient', ['get']);
+        matSnackBarMock = jasmine.createSpyObj('MatLegacySnackBar', ['open']);
+        component = new HttpBlockComponent(contextDataServiceMock, matSnackBarMock, httpClientMock);
+    });
+
+    it('should extract the next page URL from a link header', () => {
+        const linkHeader = '<https://example.com/page2>; rel="next"';
+        expect(component.extractNextPageUrl(linkHeader)).toEqual('https://example.com/page2');
+    });
+
+    it('should return null if no next link is present', () => {
+        const linkHeader = '<https://example.com/page2>; rel="last"';
+        expect(component.extractNextPageUrl(linkHeader)).toBeNull();
+    });
+
+    it('should return null for an invalid link header', () => {
+        const linkHeader = 'invalid link header';
+        expect(component.extractNextPageUrl(linkHeader)).toBeNull();
+    });
+
+    it('should return null for an empty string', () => {
+        expect(component.extractNextPageUrl('')).toBeNull();
+    });
+});

--- a/src/app/blocks/http-block/http-block.component.ts
+++ b/src/app/blocks/http-block/http-block.component.ts
@@ -1,11 +1,11 @@
-import {Component, EventEmitter, Input, OnChanges, OnInit, Output} from '@angular/core';
-import {get, has, includes, isString, toUpper} from 'lodash-es';
-import {ContextDataService} from '../../services/context-data.service';
-import {HttpClient, HttpHeaders, HttpParams} from '@angular/common/http';
+import { Component, EventEmitter, Input, OnChanges, OnInit, Output } from '@angular/core';
+import { get, has, includes, isString, toUpper } from 'lodash-es';
+import { ContextDataService } from '../../services/context-data.service';
+import { HttpClient, HttpHeaders, HttpParams } from '@angular/common/http';
 import { MatLegacySnackBar as MatSnackBar } from '@angular/material/legacy-snack-bar';
-import {catchError} from 'rxjs/operators';
-import {of} from 'rxjs';
-import {mappingUtility} from '../mapping-block/mapping-util';
+import { catchError } from 'rxjs/operators';
+import { of } from 'rxjs';
+import { mappingUtility } from '../mapping-block/mapping-util';
 import settings from 'cluster';
 
 @Component({
@@ -105,17 +105,17 @@ export class HttpBlockComponent implements OnInit, OnChanges {
 
     if (has(this.config, 'authentication.type')) {
       const valueGetters = get(this.config, 'authentication.valueGetters', {});
-      const context = {...this.config.authentication, ...this.contextData.getGlobalContext(valueGetters, this.context, this.model)};
+      const context = { ...this.config.authentication, ...this.contextData.getGlobalContext(valueGetters, this.context, this.model) };
       switch (get(this.config, 'authentication.type')) {
         case 'basic-auth':
           if (has(context, 'username') && has(context, 'password')) {
-            const {username, password} = context;
+            const { username, password } = context;
             headers = headers.append('Authorization', 'Basic ' + btoa(`${username}:${password}`));
           }
           break;
         case 'bearer':
           if (has(context, 'jwt')) {
-            const {jwt} = context;
+            const { jwt } = context;
             headers = headers.append('Authorization', `Bearer ${jwt}`);
           }
           break;
@@ -123,15 +123,15 @@ export class HttpBlockComponent implements OnInit, OnChanges {
           console.log('Unknown authentication type');
       }
     }
-    
+
     // TODO: decide what to do with response when error condition
     switch (toUpper(method)) {
       case 'GET':
         // force the service worker bypass. 
         // When calls are passed to the service worker, they can be invisibly cached
         // by forcing a bypass, we have more control to force a call to take place
-        headers = headers.append('ngsw-bypass','true');
-        this.http.get(url, {headers, responseType: this.responseType})
+        headers = headers.append('ngsw-bypass', 'true');
+        this.http.get(url, { headers, responseType: this.responseType })
           .pipe(
             catchError(error => {
               this.hasError = true;
@@ -148,7 +148,7 @@ export class HttpBlockComponent implements OnInit, OnChanges {
           });
         break;
       case 'DELETE':
-        this.http.delete(url, {headers, responseType: this.responseType})
+        this.http.delete(url, { headers, responseType: this.responseType })
           .pipe(
             catchError(error => {
               this.hasError = true;
@@ -176,7 +176,7 @@ export class HttpBlockComponent implements OnInit, OnChanges {
 
           return;
         }
-        this.http.put(url, payloadB, {headers, responseType: this.responseType})
+        this.http.put(url, payloadB, { headers, responseType: this.responseType })
           .pipe(
             catchError(error => {
               this.hasError = true;
@@ -219,10 +219,10 @@ export class HttpBlockComponent implements OnInit, OnChanges {
           return;
         }
         const sub = (toUpper(method) === 'PUT')
-          ? this.http.put(url, payload, {headers, responseType: this.responseType})
+          ? this.http.put(url, payload, { headers, responseType: this.responseType })
           : (toUpper(method) === 'PATCH') ?
-            this.http.patch(url, payload, {headers, responseType: this.responseType})
-            : this.http.post(url, payload, {headers, responseType: this.responseType});
+            this.http.patch(url, payload, { headers, responseType: this.responseType })
+            : this.http.post(url, payload, { headers, responseType: this.responseType });
         sub
           .pipe(
             catchError(error => {
@@ -259,7 +259,7 @@ export class HttpBlockComponent implements OnInit, OnChanges {
   getPayloadHeaders() {
     const headers = get(this.config, 'headers', {});
     return Object.keys(headers).reduce((a, key) => {
-      a[key] = mappingUtility({data: this.model, context: this.context}, headers[key]);
+      a[key] = mappingUtility({ data: this.model, context: this.context }, headers[key]);
       return a;
     }, {});
   }
@@ -267,7 +267,7 @@ export class HttpBlockComponent implements OnInit, OnChanges {
   getPayload() {
     const payloadMapping = get(this.config, 'payload');
     if (payloadMapping) {
-      return mappingUtility({data: this.model, context: this.context}, payloadMapping);
+      return mappingUtility({ data: this.model, context: this.context }, payloadMapping);
     }
     return this.model;
   }

--- a/src/app/blocks/http-block/http-block.component.ts
+++ b/src/app/blocks/http-block/http-block.component.ts
@@ -126,7 +126,7 @@ export class HttpBlockComponent implements OnInit, OnChanges {
           console.log('Unknown authentication type');
       }
     }
-    
+
     // TODO: decide what to do with response when error condition
     switch (toUpper(method)) {
       case 'GET':
@@ -154,106 +154,106 @@ export class HttpBlockComponent implements OnInit, OnChanges {
             });
         }
         break;
-        case 'DELETE':
-          this.http.delete(url, { headers, responseType: this.responseType })
-            .pipe(
-              catchError(error => {
-                this.hasError = true;
-                this.errorMessage = error.message;
-                this.errorData = error;
-                // TODO: need to prevent errors for triggering subsequent blocks
-                return of([]);
-              })
-            )
-            .subscribe(response => {
-              this.isLoading = false;
-              this.hasError = false;
-              this.outputResult(response);
-            });
-          break;
-        case 'BPUT': // binary PUT
-          const isArrayBufferWithContent = obj => (obj instanceof ArrayBuffer) && obj.byteLength > 0;
-          const payloadB = get(this.model, 'content');
-          if (!isArrayBufferWithContent(payloadB)) {
+      case 'DELETE':
+        this.http.delete(url, { headers, responseType: this.responseType })
+          .pipe(
+            catchError(error => {
+              this.hasError = true;
+              this.errorMessage = error.message;
+              this.errorData = error;
+              // TODO: need to prevent errors for triggering subsequent blocks
+              return of([]);
+            })
+          )
+          .subscribe(response => {
             this.isLoading = false;
-            this.hasError = true;
-            this.errorMessage = `${toUpper(method)} of empty payload prevented in http block`;
-            this.errorData = {};
-            this.errorBlocks = [];
-        
-            return;
-          }
-          this.http.put(url, payloadB, { headers, responseType: this.responseType })
-            .pipe(
-              catchError(error => {
-                this.hasError = true;
-                this.errorMessage = error.message;
-                this.errorData = error;
-                // TODO: need to prevent errors for triggering subsequent blocks
-                return of([]);
-              })
-            )
-            .subscribe(response => {
-              this.isLoading = false;
-              this.hasError = false;
-              this.outputResult(response);
-              const notify = get(this.config, 'notify', true);
-              if (notify) {
-                const message = 'API update successful';
-                this.notify.open(message, 'OK', {
-                  duration: 2000,
-                  verticalPosition: 'top'
-                });
-              }
-            });
-          break;
-        case 'PUT':
-        case 'POST':
-        case 'PATCH':
-          const isEmptyObject = obj => (obj instanceof Object && Object.keys(obj).length === 0);
-          let payload = this.getPayload();
-          if ('application/x-www-form-urlencoded' === get(this.config, 'requestType', 'application/json')) {
-            payload = (new HttpParams({ fromObject: payload })).toString();
-            headers = headers.set('Content-Type', 'application/x-www-form-urlencoded');
-          }
-          if (isEmptyObject(payload)) {
+            this.hasError = false;
+            this.outputResult(response);
+          });
+        break;
+      case 'BPUT': // binary PUT
+        const isArrayBufferWithContent = obj => (obj instanceof ArrayBuffer) && obj.byteLength > 0;
+        const payloadB = get(this.model, 'content');
+        if (!isArrayBufferWithContent(payloadB)) {
+          this.isLoading = false;
+          this.hasError = true;
+          this.errorMessage = `${toUpper(method)} of empty payload prevented in http block`;
+          this.errorData = {};
+          this.errorBlocks = [];
+
+          return;
+        }
+        this.http.put(url, payloadB, { headers, responseType: this.responseType })
+          .pipe(
+            catchError(error => {
+              this.hasError = true;
+              this.errorMessage = error.message;
+              this.errorData = error;
+              // TODO: need to prevent errors for triggering subsequent blocks
+              return of([]);
+            })
+          )
+          .subscribe(response => {
             this.isLoading = false;
-            this.hasError = true;
-            this.errorMessage = `${toUpper(method)} of empty payload prevented in http block`;
-            this.errorData = {};
-            this.errorBlocks = [];
-        
-            return;
-          }
-          const sub = (toUpper(method) === 'PUT')
-            ? this.http.put(url, payload, { headers, responseType: this.responseType })
-            : (toUpper(method) === 'PATCH') ?
-              this.http.patch(url, payload, { headers, responseType: this.responseType })
-              : this.http.post(url, payload, { headers, responseType: this.responseType });
-          sub
-            .pipe(
-              catchError(error => {
-                this.hasError = true;
-                this.errorMessage = error.message;
-                this.errorData = error;
-                // TODO: need to prevent errors for triggering subsequent blocks
-                return of([]);
-              })
-            )
-            .subscribe(response => {
-              this.isLoading = false;
-              this.hasError = false;
-              this.outputResult(response);
-              const notify = get(this.config, 'notify', true);
-              if (notify) {
-                const message = 'API update successful';
-                this.notify.open(message, 'OK', {
-                  duration: 2000,
-                  verticalPosition: 'top'
-                });
-              }
-            });
-          break;
+            this.hasError = false;
+            this.outputResult(response);
+            const notify = get(this.config, 'notify', true);
+            if (notify) {
+              const message = 'API update successful';
+              this.notify.open(message, 'OK', {
+                duration: 2000,
+                verticalPosition: 'top'
+              });
+            }
+          });
+        break;
+      case 'PUT':
+      case 'POST':
+      case 'PATCH':
+        const isEmptyObject = obj => (obj instanceof Object && Object.keys(obj).length === 0);
+        let payload = this.getPayload();
+        if ('application/x-www-form-urlencoded' === get(this.config, 'requestType', 'application/json')) {
+          payload = (new HttpParams({ fromObject: payload })).toString();
+          headers = headers.set('Content-Type', 'application/x-www-form-urlencoded');
+        }
+        if (isEmptyObject(payload)) {
+          this.isLoading = false;
+          this.hasError = true;
+          this.errorMessage = `${toUpper(method)} of empty payload prevented in http block`;
+          this.errorData = {};
+          this.errorBlocks = [];
+
+          return;
+        }
+        const sub = (toUpper(method) === 'PUT')
+          ? this.http.put(url, payload, { headers, responseType: this.responseType })
+          : (toUpper(method) === 'PATCH') ?
+            this.http.patch(url, payload, { headers, responseType: this.responseType })
+            : this.http.post(url, payload, { headers, responseType: this.responseType });
+        sub
+          .pipe(
+            catchError(error => {
+              this.hasError = true;
+              this.errorMessage = error.message;
+              this.errorData = error;
+              // TODO: need to prevent errors for triggering subsequent blocks
+              return of([]);
+            })
+          )
+          .subscribe(response => {
+            this.isLoading = false;
+            this.hasError = false;
+            this.outputResult(response);
+            const notify = get(this.config, 'notify', true);
+            if (notify) {
+              const message = 'API update successful';
+              this.notify.open(message, 'OK', {
+                duration: 2000,
+                verticalPosition: 'top'
+              });
+            }
+          });
+        break;
     }
   }
 
@@ -338,15 +338,15 @@ export class HttpBlockComponent implements OnInit, OnChanges {
       // and return an object with the URL and relation type.
 
       const matches = /<(.*)>; rel="(.*)"/.exec(link.trim());
-      if (matches && matches.length === 3) {
+      if (matches?.length === 3) {
         return { url: matches[1], rel: matches[2] };
       }
     });
 
     // Get the first link that matches the condition:
-    const nextPageLink = links.find(link => link && link.rel === 'next');
+    const nextPageLink = links.find(link => link?.rel === 'next');
     // We return the URL of the next page if it exists, or null otherwise.
-    return nextPageLink ? nextPageLink.url : null;
+    return nextPageLink?.url || null;
   }
 
   outputResult(data) {

--- a/src/app/blocks/http-block/http-block.component.ts
+++ b/src/app/blocks/http-block/http-block.component.ts
@@ -1,12 +1,11 @@
 import { Component, EventEmitter, Input, OnChanges, OnInit, Output } from '@angular/core';
 import { get, has, includes, isString, toUpper } from 'lodash-es';
 import { ContextDataService } from '../../services/context-data.service';
-import { HttpClient, HttpHeaders, HttpParams } from '@angular/common/http';
+import { HttpClient, HttpHeaders, HttpParams, HttpResponse } from '@angular/common/http';
 import { MatLegacySnackBar as MatSnackBar } from '@angular/material/legacy-snack-bar';
-import { catchError } from 'rxjs/operators';
-import { of } from 'rxjs';
+import { catchError, expand, reduce, takeWhile } from 'rxjs/operators';
+import { of, EMPTY } from 'rxjs';
 import { mappingUtility } from '../mapping-block/mapping-util';
-import settings from 'cluster';
 
 @Component({
   selector: 'app-http-block',
@@ -67,6 +66,10 @@ export class HttpBlockComponent implements OnInit, OnChanges {
     this.makeRequest();
   }
 
+  /**
+   * Makes an HTTP request based on the provided configuration and handles the response.
+   * It also supports pagination by calling the getAllPages method when followPaginationLinksMerged option is enabled.
+   */
   makeRequest() {
     this.hasError = false;
     this.isLoading = true;
@@ -123,7 +126,7 @@ export class HttpBlockComponent implements OnInit, OnChanges {
           console.log('Unknown authentication type');
       }
     }
-
+    
     // TODO: decide what to do with response when error condition
     switch (toUpper(method)) {
       case 'GET':
@@ -131,125 +134,219 @@ export class HttpBlockComponent implements OnInit, OnChanges {
         // When calls are passed to the service worker, they can be invisibly cached
         // by forcing a bypass, we have more control to force a call to take place
         headers = headers.append('ngsw-bypass', 'true');
-        this.http.get(url, { headers, responseType: this.responseType })
-          .pipe(
-            catchError(error => {
-              this.hasError = true;
-              this.errorMessage = error.message;
-              this.errorData = error;
-              // TODO: need to prevent errors for triggering subsequent blocks
-              return of([]);
-            })
-          )
-          .subscribe(response => {
-            this.isLoading = false;
-            this.hasError = false;
-            this.outputResult(response);
-          });
-        break;
-      case 'DELETE':
-        this.http.delete(url, { headers, responseType: this.responseType })
-          .pipe(
-            catchError(error => {
-              this.hasError = true;
-              this.errorMessage = error.message;
-              this.errorData = error;
-              // TODO: need to prevent errors for triggering subsequent blocks
-              return of([]);
-            })
-          )
-          .subscribe(response => {
-            this.isLoading = false;
-            this.hasError = false;
-            this.outputResult(response);
-          });
-        break;
-      case 'BPUT': // binary PUT
-        const isArrayBufferWithContent = obj => (obj instanceof ArrayBuffer) && obj.byteLength > 0;
-        const payloadB = get(this.model, 'content');
-        if (!isArrayBufferWithContent(payloadB)) {
-          this.isLoading = false;
-          this.hasError = true;
-          this.errorMessage = `${toUpper(method)} of empty payload prevented in http block`;
-          this.errorData = {};
-          this.errorBlocks = [];
-
-          return;
+        if (get(this.config, 'followPaginationLinksMerged', false)) {
+          this.getAllPages(url, headers, this.responseType);
+        } else {
+          this.http.get(url, { headers, responseType: this.responseType })
+            .pipe(
+              catchError(error => {
+                this.hasError = true;
+                this.errorMessage = error.message;
+                this.errorData = error;
+                // TODO: need to prevent errors for triggering subsequent blocks
+                return of([]);
+              })
+            )
+            .subscribe(response => {
+              this.isLoading = false;
+              this.hasError = false;
+              this.outputResult(response);
+            });
         }
-        this.http.put(url, payloadB, { headers, responseType: this.responseType })
-          .pipe(
-            catchError(error => {
-              this.hasError = true;
-              this.errorMessage = error.message;
-              this.errorData = error;
-              // TODO: need to prevent errors for triggering subsequent blocks
-              return of([]);
-            })
-          )
-          .subscribe(response => {
+        break;
+        case 'DELETE':
+          this.http.delete(url, { headers, responseType: this.responseType })
+            .pipe(
+              catchError(error => {
+                this.hasError = true;
+                this.errorMessage = error.message;
+                this.errorData = error;
+                // TODO: need to prevent errors for triggering subsequent blocks
+                return of([]);
+              })
+            )
+            .subscribe(response => {
+              this.isLoading = false;
+              this.hasError = false;
+              this.outputResult(response);
+            });
+          break;
+        case 'BPUT': // binary PUT
+          const isArrayBufferWithContent = obj => (obj instanceof ArrayBuffer) && obj.byteLength > 0;
+          const payloadB = get(this.model, 'content');
+          if (!isArrayBufferWithContent(payloadB)) {
             this.isLoading = false;
-            this.hasError = false;
-            this.outputResult(response);
-            const notify = get(this.config, 'notify', true);
-            if (notify) {
-              const message = 'API update successful';
-              this.notify.open(message, 'OK', {
-                duration: 2000,
-                verticalPosition: 'top'
-              });
+            this.hasError = true;
+            this.errorMessage = `${toUpper(method)} of empty payload prevented in http block`;
+            this.errorData = {};
+            this.errorBlocks = [];
+        
+            return;
+          }
+          this.http.put(url, payloadB, { headers, responseType: this.responseType })
+            .pipe(
+              catchError(error => {
+                this.hasError = true;
+                this.errorMessage = error.message;
+                this.errorData = error;
+                // TODO: need to prevent errors for triggering subsequent blocks
+                return of([]);
+              })
+            )
+            .subscribe(response => {
+              this.isLoading = false;
+              this.hasError = false;
+              this.outputResult(response);
+              const notify = get(this.config, 'notify', true);
+              if (notify) {
+                const message = 'API update successful';
+                this.notify.open(message, 'OK', {
+                  duration: 2000,
+                  verticalPosition: 'top'
+                });
+              }
+            });
+          break;
+        case 'PUT':
+        case 'POST':
+        case 'PATCH':
+          const isEmptyObject = obj => (obj instanceof Object && Object.keys(obj).length === 0);
+          let payload = this.getPayload();
+          if ('application/x-www-form-urlencoded' === get(this.config, 'requestType', 'application/json')) {
+            payload = (new HttpParams({ fromObject: payload })).toString();
+            headers = headers.set('Content-Type', 'application/x-www-form-urlencoded');
+          }
+          if (isEmptyObject(payload)) {
+            this.isLoading = false;
+            this.hasError = true;
+            this.errorMessage = `${toUpper(method)} of empty payload prevented in http block`;
+            this.errorData = {};
+            this.errorBlocks = [];
+        
+            return;
+          }
+          const sub = (toUpper(method) === 'PUT')
+            ? this.http.put(url, payload, { headers, responseType: this.responseType })
+            : (toUpper(method) === 'PATCH') ?
+              this.http.patch(url, payload, { headers, responseType: this.responseType })
+              : this.http.post(url, payload, { headers, responseType: this.responseType });
+          sub
+            .pipe(
+              catchError(error => {
+                this.hasError = true;
+                this.errorMessage = error.message;
+                this.errorData = error;
+                // TODO: need to prevent errors for triggering subsequent blocks
+                return of([]);
+              })
+            )
+            .subscribe(response => {
+              this.isLoading = false;
+              this.hasError = false;
+              this.outputResult(response);
+              const notify = get(this.config, 'notify', true);
+              if (notify) {
+                const message = 'API update successful';
+                this.notify.open(message, 'OK', {
+                  duration: 2000,
+                  verticalPosition: 'top'
+                });
+              }
+            });
+          break;
+    }
+  }
+
+
+  /**
+   * Fetches paginated API results by recursively getting each page and merging the results.
+   * @param {string} url - The endpoint URL.
+   * @param {HttpHeaders} headers - The HttpHeaders for the request.
+   * @param {string} responseType - The type of response expected from the server.
+   */
+  getAllPages(url, headers, responseType) {
+    // Expands through pages recursively based on nextPageUrl
+    this.http.get(url, { headers, responseType, observe: 'response' })
+      .pipe(
+        expand((response: HttpResponse<any>) => {
+          const linkHeader = response.headers.get('link');
+          const nextPageUrl = this.extractNextPageUrl(linkHeader);
+
+          if (nextPageUrl) {
+            if (get(this.config, 'useProxy', false)) {
+              headers = headers.delete('Target-URL');
+              headers = headers.append('Target-URL', nextPageUrl);
+            } else {
+              url = nextPageUrl;
             }
-          });
-        break;
-      case 'PUT':
-      case 'POST':
-      case 'PATCH':
-        const isEmptyObject = obj => (obj instanceof Object && Object.keys(obj).length === 0);
-        let payload = this.getPayload();
-        if ('application/x-www-form-urlencoded' === get(this.config, 'requestType', 'application/json')) {
-          payload = (new HttpParams({ fromObject: payload })).toString();
-          headers = headers.set('Content-Type', 'application/x-www-form-urlencoded');
-        }
-        if (isEmptyObject(payload)) {
-          this.isLoading = false;
+            return this.http.get(url, { headers, responseType, observe: 'response' });
+          } else {
+            return EMPTY;
+          }
+        }),
+        takeWhile(response => response.status === 200), // Stop when there's an error or nextPageUrl is null
+        catchError(error => {
           this.hasError = true;
-          this.errorMessage = `${toUpper(method)} of empty payload prevented in http block`;
-          this.errorData = {};
-          this.errorBlocks = [];
+          this.errorMessage = error.message;
+          this.errorData = error;
+          return of([]);
+        }),
+        reduce((accumlated_results: any[], response: HttpResponse<any>) => accumlated_results.concat(response.body || []), [])
+      )
+      .subscribe(results => {
+        this.isLoading = false;
+        this.hasError = false;
+        this.outputResult(results);
+      });
+  }
 
-          return;
-        }
-        const sub = (toUpper(method) === 'PUT')
-          ? this.http.put(url, payload, { headers, responseType: this.responseType })
-          : (toUpper(method) === 'PATCH') ?
-            this.http.patch(url, payload, { headers, responseType: this.responseType })
-            : this.http.post(url, payload, { headers, responseType: this.responseType });
-        sub
-          .pipe(
-            catchError(error => {
-              this.hasError = true;
-              this.errorMessage = error.message;
-              this.errorData = error;
-              // TODO: need to prevent errors for triggering subsequent blocks
-              return of([]);
-            })
-          )
-          .subscribe(response => {
-            this.isLoading = false;
-            this.hasError = false;
-            this.outputResult(response);
-            const notify = get(this.config, 'notify', true);
-            if (notify) {
-              const message = 'API update successful';
-              this.notify.open(message, 'OK', {
-                duration: 2000,
-                verticalPosition: 'top'
-              });
-            }
-          });
-        break;
-
+  /**
+   * Extracts the next page URL from the link header in the HttpResponse.
+   * @param {string} linkHeader - The link header string from HttpResponse.
+   * @return {string|null} - The next page URL if it exists, or null otherwise.
+   */
+  extractNextPageUrl(linkHeader) {
+    /**
+     * The `link` header should follow the format outlined by RFC 5988 Web Linking. 
+     * It should contain a list of link relations and their respective URLs, separated 
+     * by commas. Each link consists of the URL enclosed in angle brackets `< >` 
+     * followed by a semicolon and the relation type specified as `rel="relation-type"`.
+     * 
+     * Example of a link header:
+     * `<linkHeader> = '<https://example.com/data?page=2>; rel="next", 
+     *                 <https://example.com/data?page=5>; rel="last"'`
+     * 
+     * In this example, there is a "next" relation pointing to the second page of results,
+     * and a "last" relation pointing to the fifth (and final) page of results.
+     * 
+     * The `extractNextPageUrl` method will specifically look for a link with the `rel="next"` 
+     * attribute and return its URL. In case there's no "next" relation, the method will 
+     * return null, which is considered the stop condition for pagination. 
+     */
+    if (!linkHeader) {
+      return null;
     }
 
+
+    // We use a regex to extract the URL and relation type from each link,
+    // and return an object with the URL and relation type.
+    const links = linkHeader.split(',').map(link => {
+      // The regex will match the first pair of angle brackets enclosing the URL,
+      // and the first pair of double quotes enclosing the relation type.
+      // Example: `<https://example.com/data?page=2>; rel="next"`
+      // The regex will match `<https://example.com/data?page=2>` and `next`
+      // and return an object with the URL and relation type.
+
+      const matches = /<(.*)>; rel="(.*)"/.exec(link.trim());
+      if (matches && matches.length === 3) {
+        return { url: matches[1], rel: matches[2] };
+      }
+    });
+
+    // Get the first link that matches the condition:
+    const nextPageLink = links.find(link => link && link.rel === 'next');
+    // We return the URL of the next page if it exists, or null otherwise.
+    return nextPageLink ? nextPageLink.url : null;
   }
 
   outputResult(data) {


### PR DESCRIPTION
When HTTP block config declares followPaginationLinksMerged as true, the block will try to follow linked pages and combine the results into a single combined array.

After getting a page, if the `link` response header links to a next page, it requests it (until there are no more) then it merges results to return a single output.


You can see it in use here, where instead of the usual 1 request with up to 100 results, there are hundreds of results and quite a few HTTP requests made:

https://kendraio-app-git-paginated-http-block-kendraio.vercel.app/mygreenpod/cart