### PR TITLE
Angular material theme import fix (GH issue #370)

### DIFF
--- a/src/styles.scss
+++ b/src/styles.scss
@@ -22,8 +22,11 @@
 //  If you don't need the default component typographies but still want the hierarchy styles,
 //  you can delete this line and instead use:
 //    `@include mat.legacy-typography-hierarchy(mat.define-legacy-typography-config());`
+
 @include mat.all-legacy-component-typographies();
 @include mat.legacy-core();
+@import '@angular/material/theming';
+@include mat-core();
 
 // Define the palettes for your theme using the Material Design palettes available in palette.scss
 // (imported above). For each palette, you can optionally specify a default, lighter, and darker
@@ -35,12 +38,22 @@ $kendraio-app-accent: mat.define-palette(mat.$orange-palette, A200, A100, A400);
 $kendraio-app-warn: mat.define-palette(mat.$red-palette);
 
 // Create the theme object (a Sass map containing all of the palettes).
-$kendraio-app-theme: mat.define-light-theme($kendraio-app-primary, $kendraio-app-accent, $kendraio-app-warn);
+$kendraio-app-theme: mat.define-light-theme((
+  color: (
+    primary: $kendraio-app-primary,
+    accent: $kendraio-app-accent,
+    warn: $kendraio-app-warn
+  ),
+  typography: mat.define-typography-config(),
+  density: 0, 
+));
+ 
 
 // Include theme styles for core and each component used in your app.
 // Alternatively, you can import and @include the theme mixins for each component
 // that you are using.
 @include mat.all-legacy-component-themes($kendraio-app-theme);
+@include angular-material-theme($kendraio-app-theme);
 
 
 html, body { height: 100%; overflow: hidden; }

--- a/src/styles/vendor.scss
+++ b/src/styles/vendor.scss
@@ -5,16 +5,15 @@
  * Licensed under MIT (https://github.com/twbs/bootstrap/blob/master/LICENSE)
  */
 
- @import "~bootstrap/dist/css/bootstrap.css";
+@import "~bootstrap/dist/css/bootstrap.css";
 
 // Our own variables that override bootstrap
 @import "_variables";
 
 // Utility classes
-//@import "~bootstrap/scss/utilities";
+@import "node_modules/bootstrap/scss/bootstrap-utilities.scss";
 @import "progress-bar";
-// @import '@angular/material/prebuilt-themes/purple-green.css';
-//  @import '@angular/material/prebuilt-themes/deeppurple-amber.css';
+
 /*
  * Font Awesome 4.x
  */


### PR DESCRIPTION
You should be able to go to:

https://kendraio-app-git-angular-material-theme-import-7b70b9-kendraio.vercel.app/localloop/filterTransactionsByOrg

and see that the dropdown  has a background and in general things are formatted better than main's prod deployment:

https://app.kendra.io/localloop/filterTransactionsByOrg