### PR TITLE
Add ISO 8601 example to Mapping docs

### DIFF
--- a/docs/workflow/blocks/mapping.rst
+++ b/docs/workflow/blocks/mapping.rst
@@ -369,6 +369,8 @@ Examples:
 
    formatDate('2020-01-01', 'dd/MM/yyyy')  // Output: "01/01/2020"
 
+   formatDate('2020-01-01T14:50:00.000+01:00', 'dd/MM/yyyy') // Output: "01/01/2020"
+
 10. omit
 --------
 


### PR DESCRIPTION
Add ISO 8601 example for formatDate() in JMESPath Mapping documentation