### PR TITLE
Return error information on HTTP block request

### DIFF
--- a/docs/workflow/blocks/form.rst
+++ b/docs/workflow/blocks/form.rst
@@ -44,7 +44,7 @@ not dependent on the form, then it is best to place them before the form in the 
 
 Config init
 -----------
-If can often be beneficial to initialiase the form data by creating an mapping of the default data. 
+It can often be beneficial to initialiase the form data by creating a mapping of the default data. 
 
 .. code-block:: json 
 
@@ -52,13 +52,75 @@ If can often be beneficial to initialiase the form data by creating an mapping o
     "confirm": false
   }
 
-
 Examples
 ---------
 
+Read-only
+^^^^^^^^^
+Display a field in read-only mode (not editable)
+
+.. code-block:: json
+
+  {
+    "type": "form",
+    "label": "Search",
+    "jsonSchema": {
+        "type": "object",
+        "properties": {
+            "name": {
+                "type": "string",
+                "title": "Artist name",
+                "readOnly": true
+            }
+        }
+    },
+    "uiSchema": {}
+  }
+
+Form validation
+^^^^^^^^^^^^^^^
+
+Dynamic field title
+^^^^^^^^^^^^^^^^^^^
+Using dynamic data as title for the form field
+
+.. code-block:: json
+  
+
+  // data
+  {
+    "name": `John`,
+    "surname": `Doe`
+  }
+
+  // Form config
+  {
+    "type": "form",
+    "jsonSchema": {
+        "type": "object",
+        "properties": {
+            "title": {
+                "type": "string",
+                "title": "I am harcoded text"
+            },
+            "user_name": {
+                "type": "string",
+                "title": "name",
+                "default": "titlte of this field come from dynamic data"
+            },
+            "user_surname": {
+                "type": "string",
+                "title": "surname",
+                "default": "titlte of this field come from dynamic data"
+            }
+        }
+    },
+    "uiSchema": {}
+}
+
+
 No submit button
 ^^^^^^^^^^^^^^^^
-
 A simple search form without a submit button. 
 
 .. code-block:: json

--- a/docs/workflow/blocks/mapping.rst
+++ b/docs/workflow/blocks/mapping.rst
@@ -74,6 +74,14 @@ Output will be:
   surname:"Doe"
   iAmNull:null
 
+Is also possible to wrap the whole expression in backtick. The output will be the same:
+
+.. code-block:: json
+  `{
+    "name": "John",
+    "surname": "Doe",
+    "iAmNotNull": "now this value is visible too"
+  }`
 
 
 Not

--- a/docs/workflow/blocks/mapping.rst
+++ b/docs/workflow/blocks/mapping.rst
@@ -53,9 +53,31 @@ read from *filter*. Reading from  *state.global.workflowCloud.listWorkflows.filt
 Handy JMESPath patterns
 -----------------------
 
+Using string as value
+^^^^^^^^^^^^^^^^^^^^
+When manually creating data, a string will be passed as value.
+Usually keys and values are wrapped in double quotes, to be valid JMESPath.
+In the case of an hardcoded string, the value must be wrapped in backtick, otherwise it will result `null`
+
+.. code-block:: json
+  {
+    "name": `John`,
+    "surname": `Doe`,
+    "iAmNull": "not showing"
+  }
+
+Output will be:
+
+.. code-block:: text
+
+  name:"John"
+  surname:"Doe"
+  iAmNull:null
+
+
+
 Not
 ^^^
-
 When your data structuture holds the value that you wish to negate, you need to enclose the 
 path of your data in parentheses before you NOT it. 
 

--- a/docs/workflow/blocks/variable_set.rst
+++ b/docs/workflow/blocks/variable_set.rst
@@ -6,10 +6,10 @@ Save a value to local storage.
 
 Supported properties
 --------------------
-  **name**: The name of the variable 
-   **showNotify** (boolean) (default=true): Display a notification that the variable has been set
-   **nameGetter** : Provide a location for the variable name
-   **valueGetter**: Provide a location for the variable value
+- **name**: The name of the variable 
+- **showNotify** (boolean) (default=true): Display a notification that the variable has been set
+- **nameGetter** : Provide a location for the variable name
+- **valueGetter**: Provide a location for the variable value
 
 
 Default config

--- a/src/app/blocks/http-block/http-block.component.ts
+++ b/src/app/blocks/http-block/http-block.component.ts
@@ -144,7 +144,7 @@ export class HttpBlockComponent implements OnInit, OnChanges {
                 this.errorMessage = error.message;
                 this.errorData = error;
                 // TODO: need to prevent errors for triggering subsequent blocks
-                return of([]);
+                return of({error, hasError: this.hasError, errorMessage: this.errorMessage});
               })
             )
             .subscribe(response => {
@@ -162,7 +162,7 @@ export class HttpBlockComponent implements OnInit, OnChanges {
               this.errorMessage = error.message;
               this.errorData = error;
               // TODO: need to prevent errors for triggering subsequent blocks
-              return of([]);
+              return of({error, hasError: this.hasError, errorMessage: this.errorMessage});
             })
           )
           .subscribe(response => {
@@ -190,7 +190,7 @@ export class HttpBlockComponent implements OnInit, OnChanges {
               this.errorMessage = error.message;
               this.errorData = error;
               // TODO: need to prevent errors for triggering subsequent blocks
-              return of([]);
+              return of({error, hasError: this.hasError, errorMessage: this.errorMessage});
             })
           )
           .subscribe(response => {
@@ -237,7 +237,7 @@ export class HttpBlockComponent implements OnInit, OnChanges {
               this.errorMessage = error.message;
               this.errorData = error;
               // TODO: need to prevent errors for triggering subsequent blocks
-              return of([]);
+              return of({error, hasError: this.hasError, errorMessage: this.errorMessage});
             })
           )
           .subscribe(response => {
@@ -382,6 +382,7 @@ export class HttpBlockComponent implements OnInit, OnChanges {
     const pathname = get(endpoint, 'pathname', '/');
     const query = get(endpoint, 'query', []);
     const reduceQuery = _q => Object.keys(_q).map(key => `${key}=${_q[key]}`, []).join('&');
+
     return `${protocol}//${host}${pathname}?${reduceQuery(query)}`;
   }
 }


### PR DESCRIPTION
Currently, the HTTP block handle error in the code but it does not return any information about it.
If a GET/POST/PUT/... request is made and an error is raised, the data object in the flow is `null`

With this PR the data object in the flow, will now return the error information.
It also contain a very handy `hasError: true` property so it can be easily check for error or not and potentially display error messages in the flow.

Here two screenshots of how the result will be:
![image](https://github.com/kendraio/kendraio-app/assets/1055531/fa432677-f17b-4551-a9d7-0c1547120a38)
![image](https://github.com/kendraio/kendraio-app/assets/1055531/7de47433-5789-4997-8c46-a48dbd819603)

And here is a flow that can be use to test this PR: https://app.kendra.io/harvest-timesheet/harvestTimesheet
