### PR TITLE
Return error information on HTTP block request

### DIFF
--- a/cypress/e2e/http_block.ts
+++ b/cypress/e2e/http_block.ts
@@ -81,13 +81,14 @@ describe('HTTP Block Request', () => {
             },
             {
                 "type": "debug",
-                "open": 2,
+                "open": 3,
                 "showData": true
             }
         ]);
 
-        console.log
-        cy.contains('hasError');
+        cy.contains('hasError:true');
+        cy.contains('status:400');
+        cy.contains('errorMessage:"Http failure response for https://example.com/data: 400 Bad Request"');
         cy.get('app-template-block').contains('Error with submission')
     });
 

--- a/cypress/e2e/http_block.ts
+++ b/cypress/e2e/http_block.ts
@@ -3,7 +3,100 @@ import { loadFlowCode } from '../support/helper';
 // tslint:disable: quotemark
 /// <reference types="Cypress" />
 
-describe('HTTP Block Integration Tests', () => {
+
+describe('HTTP Block Request', () => {
+
+    beforeEach(() => {
+        // Prevent external network request for adapter config
+        cy.intercept('GET', 'https://kendraio.github.io/kendraio-adapter/config.json', {
+            fixture: 'adapterConfig.json'
+        });
+
+        // Prevent external network requests for Workflow cloud
+        cy.intercept('GET', 'https://app.kendra.io/api/workflowCloud/listWorkflows', {
+            fixture: 'workflow-cloud.json'
+        });
+
+        // Prevent external network requests for fonts with empty CSS rule 
+        cy.intercept('https://fonts.googleapis.com/\*\*', "\*{ }");
+    });
+
+    it('should return a single set of results. Without pagination', () => {
+        cy.intercept({
+            url: 'https://example.com/data'
+        }, {
+            statusCode: 200,
+            body: '["hippo", "giraffe"]'
+        });
+
+        loadFlowCode([
+            { "type": "init" },
+            {
+                "type": "http",
+                "method": "GET",
+                "endpoint": "https://example.com/data"
+            },
+            {
+                "type": "debug",
+                "open": 2,
+                "showData": true
+            }
+        ]);
+        cy.contains('hippo');
+        cy.contains('giraffe');
+    });
+
+    it('should return an error', () => {
+        cy.intercept({
+            url: 'https://example.com/data'
+        }, {
+            statusCode: 400,
+            body: { error: {
+                        error: "Http failure 400 Bad request",
+                        error_description: "There was a problem with your request" 
+                    }   
+                }
+        });
+
+        loadFlowCode([
+            { "type": "init" },
+            {
+                "type": "http",
+                "method": "GET",
+                "endpoint": "https://example.com/data",
+                "onError": {
+                    "blocks": [
+                        {
+                            "type": "card",
+                            "blocks": [
+                                {
+                                    "type": "template",
+                                    "template": "Error with submission:<p>{{data.error.error}} - {{data.error.error_description}}</p>"
+                                }
+                            ]
+                        }
+                    ]
+                }
+
+            },
+            {
+                "type": "debug",
+                "open": 2,
+                "showData": true
+            }
+        ]);
+
+        console.log
+        cy.contains('hasError');
+        cy.get('app-template-block').contains('Error with submission')
+    });
+
+
+});
+
+
+
+describe('HTTP Block Follow Pagination', () => {
 
     beforeEach(() => {
         // Prevent external network request for adapter config
@@ -119,31 +212,6 @@ describe('HTTP Block Integration Tests', () => {
         cy.contains('birds');
     });
 
-    it('should return a single set of results if response is not paginated', () => {
-        cy.intercept({
-            url: 'https://example.com/data'
-        }, {
-            statusCode: 200,
-            body: '["hippo", "giraffe"]'
-        });
-
-        loadFlowCode([
-            { "type": "init" },
-            {
-                "type": "http",
-                "method": "GET",
-                "endpoint": "https://example.com/data"
-            },
-            {
-                "type": "debug",
-                "open": 2,
-                "showData": true
-            }
-        ]);
-        cy.contains('hippo');
-        cy.contains('giraffe');
-    });
-
     it('should return first results only if not paginated, with proxy', () => {
         cy.intercept({
             url: 'https://proxy.kendra.io/',
@@ -191,6 +259,4 @@ describe('HTTP Block Integration Tests', () => {
         // we check it does not contain a second page result:
         cy.get('body').should('not.contain', 'fish');
     });
-
-
 });

--- a/docs/workflow/blocks/http.rst
+++ b/docs/workflow/blocks/http.rst
@@ -52,7 +52,7 @@ Examples
 
 
 **Dynamic data** If the endpoint needs to be constructed from data, the endpoint can be specified as an object with a "valueGetter" attribute.
-"valueGetter" get data just from context.  
+"valueGetter" can only get data from the context.
 
 .. code-block:: json
 

--- a/docs/workflow/blocks/http.rst
+++ b/docs/workflow/blocks/http.rst
@@ -33,7 +33,7 @@ Supported properties
   property.
 - **headers** - A set of headers with header name as object key. Values are processed by JMESpath
 - **endpoint** - The request endpoint. Can take multiple forms. See below. 
-- **onError** - It expects blocks as argument. They will be process in case of HTTP request errors. 
+- **onError** - It expects blocks as argument. These blocks will be visible in case of HTTP request error. 
 
 
 Examples
@@ -82,7 +82,7 @@ Examples
 
 **Headers** 
 For advanced use cases, the payload can be constructed using a JMES Path expression.
-Custom headers can also be specified using JMES Path expressions.
+Custom headers can also be specified using JMESPath expressions.
 Be careful to write your header's value with two types of quote (double quotes + single quotes), if the value is a string.
 
 .. code-block:: json

--- a/docs/workflow/blocks/http.rst
+++ b/docs/workflow/blocks/http.rst
@@ -33,12 +33,13 @@ Supported properties
   property.
 - **headers** - A set of headers with header name as object key. Values are processed by JMESpath
 - **endpoint** - The request endpoint. Can take multiple forms. See below. 
+- **onError** - It expects blocks as argument. They will be process in case of HTTP request errors. 
 
 
 Examples
 --------
 
-For simple requests, the ``endpoint`` can just be a simple string:
+**Default** For simple requests, the ``endpoint`` can just be a simple string:
 
 .. code-block:: json
 
@@ -50,7 +51,8 @@ For simple requests, the ``endpoint`` can just be a simple string:
     }
 
 
-If the endpoint needs to be constructed from data, the endpoint can be specified as an object with a "valueGetter" attribute. 
+**Dynamic data** If the endpoint needs to be constructed from data, the endpoint can be specified as an object with a "valueGetter" attribute.
+"valueGetter" get data just from context.  
 
 .. code-block:: json
 
@@ -62,15 +64,32 @@ If the endpoint needs to be constructed from data, the endpoint can be specified
         }
     }
 
+.. code-block:: json
 
+    {
+    "type": "http",
+    "method": "get",
+    "endpoint": {
+        "protocol": "https:",
+        "host": "api.harvestapp.com/api/v2",
+        "pathname": "/reports/time/tasks",
+        "valueGetters": {
+            "query": "{ from: context.savedData.from, to: context.savedData.to }"
+        }
+    }
+  }
+
+
+**Headers** 
 For advanced use cases, the payload can be constructed using a JMES Path expression.
-Custom headers can also be specified using JMES Path expressions:
+Custom headers can also be specified using JMES Path expressions.
+Be careful to write your header's value with two types of quote (double quotes + single quotes), if the value is a string.
 
 .. code-block:: json
 
   {
       "type": "http",
-      "method": "post",
+      "Defaultmethod": "post",
       "endpoint": {
           "protocol": "https:",
           "host": "accounts.spotify.com",
@@ -83,7 +102,7 @@ Custom headers can also be specified using JMES Path expressions:
       }
   }
 
-It is possible to query a GraphQL endpoint using the HTTP block.
+**GraphQL** It is possible to query a GraphQL endpoint using the HTTP block.
 
 .. code-block:: json
 
@@ -97,6 +116,41 @@ It is possible to query a GraphQL endpoint using the HTTP block.
           "pathname": "/api/graphql"
       },
       "payload": "{ query: 'query ($token: String) {  viewer(token: $token) {    allCommitments {      id      action      plannedStart      committedOn      due      committedQuantity {        numericValue        unit {          name        }      }      note      resourceClassifiedAs {        name        category      }      involves {        id        resourceClassifiedAs {          name          category        }        trackingIdentifier      }      provider {        id        name      }      receiver {        id        name      }      inputOf {        id        name      }      outputOf {        id        name      }      scope {        id        name      }      plan {        id        name      }      isPlanDeliverable      forPlanDeliverable {        id        action        outputOf {          name        }      }      isDeletable    }  }}', variables: { token: context.vfAuth } }"
+  }
+
+
+**onError** To debug and display an error message
+
+.. code-block:: json
+
+  {
+    "type": "http",
+    "method": "get",
+    "endpoint": {
+          "protocol": "https:",
+          "host": "accounts.spotify.com",
+          "pathname": "/api/token"
+    },
+    "onError": {
+        "blocks": [
+            {
+                "type": "debug",
+                "open": 1,
+                "showData": true,
+                "showContext": false,
+                "showState": false
+            },
+            {
+                "type": "card",
+                "blocks": [
+                    {
+                        "type": "template",
+                        "template": "Error with submission:<p>{{data.error.error}} - {{data.error.error_description}}</p>"
+                    }
+                ]
+            }
+        ]
+    }
   }
 
 

--- a/docs/workflow/blocks/http.rst
+++ b/docs/workflow/blocks/http.rst
@@ -82,8 +82,8 @@ Examples
 
 **Headers** 
 For advanced use cases, the payload can be constructed using a JMES Path expression.
-Custom headers can also be specified using JMESPath expressions.
-Caution: if the custom header value is a string, header values must use two types of quotes: double quotes and single quotes.
+JMESPath expressions can be used to dynamically set header and payload values.
+Caution: if the header value is a string, it must use two types of quotes: double and single quotes, like "payload": "'grant_type=client_credentials'".
 
 .. code-block:: json
 

--- a/docs/workflow/blocks/http.rst
+++ b/docs/workflow/blocks/http.rst
@@ -33,7 +33,7 @@ Supported properties
   property.
 - **headers** - A set of headers with header name as object key. Values are processed by JMESpath
 - **endpoint** - The request endpoint. Can take multiple forms. See below. 
-- **onError** - It expects blocks as argument. These blocks will be visible in case of HTTP request error. 
+- **onError** - Define an array of blocks to show when there is an error processing the HTTP request. 
 
 
 Examples
@@ -83,13 +83,13 @@ Examples
 **Headers** 
 For advanced use cases, the payload can be constructed using a JMES Path expression.
 Custom headers can also be specified using JMESPath expressions.
-Be careful to write your header's value with two types of quote (double quotes + single quotes), if the value is a string.
+Caution: if the custom header value is a string, header values must use two types of quotes: double quotes and single quotes.
 
 .. code-block:: json
 
   {
       "type": "http",
-      "Defaultmethod": "post",
+      "method": "post",
       "endpoint": {
           "protocol": "https:",
           "host": "accounts.spotify.com",

--- a/src/app/blocks/http-block/http-block.component.ts
+++ b/src/app/blocks/http-block/http-block.component.ts
@@ -62,6 +62,7 @@ export class HttpBlockComponent implements OnInit, OnChanges {
     }
     this.responseType = get(this.config, 'responseType', 'json');
     this.errorBlocks = get(this.config, 'onError.blocks', []);
+
     this.makeRequest();
   }
 

--- a/src/app/blocks/http-block/http-block.component.ts
+++ b/src/app/blocks/http-block/http-block.component.ts
@@ -144,7 +144,7 @@ export class HttpBlockComponent implements OnInit, OnChanges {
                 this.errorMessage = error.message;
                 this.errorData = error;
                 // TODO: need to prevent errors for triggering subsequent blocks
-                return of([]);
+                return of({error, hasError: this.hasError, errorMessage: this.errorMessage});
               })
             )
             .subscribe(response => {
@@ -162,7 +162,7 @@ export class HttpBlockComponent implements OnInit, OnChanges {
               this.errorMessage = error.message;
               this.errorData = error;
               // TODO: need to prevent errors for triggering subsequent blocks
-              return of([]);
+              return of({error, hasError: this.hasError, errorMessage: this.errorMessage});
             })
           )
           .subscribe(response => {
@@ -190,7 +190,7 @@ export class HttpBlockComponent implements OnInit, OnChanges {
               this.errorMessage = error.message;
               this.errorData = error;
               // TODO: need to prevent errors for triggering subsequent blocks
-              return of([]);
+              return of({error, hasError: this.hasError, errorMessage: this.errorMessage});
             })
           )
           .subscribe(response => {
@@ -237,7 +237,7 @@ export class HttpBlockComponent implements OnInit, OnChanges {
               this.errorMessage = error.message;
               this.errorData = error;
               // TODO: need to prevent errors for triggering subsequent blocks
-              return of([]);
+              return of({error, hasError: this.hasError, errorMessage: this.errorMessage});
             })
           )
           .subscribe(response => {
@@ -382,6 +382,7 @@ export class HttpBlockComponent implements OnInit, OnChanges {
     const pathname = get(endpoint, 'pathname', '/');
     const query = get(endpoint, 'query', []);
     const reduceQuery = _q => Object.keys(_q).map(key => `${key}=${_q[key]}`, []).join('&');
+
     return `${protocol}//${host}${pathname}?${reduceQuery(query)}`;
   }
 }

--- a/src/app/blocks/http-block/http-block.component.ts
+++ b/src/app/blocks/http-block/http-block.component.ts
@@ -61,7 +61,6 @@ export class HttpBlockComponent implements OnInit, OnChanges {
       return;
     }
     this.responseType = get(this.config, 'responseType', 'json');
-    console.log({config: this.config})
     this.errorBlocks = get(this.config, 'onError.blocks', []);
     this.makeRequest();
   }
@@ -73,8 +72,6 @@ export class HttpBlockComponent implements OnInit, OnChanges {
   makeRequest() {
     this.hasError = false;
     this.isLoading = true;
-    // this.errorBlocks = [];
-    console.log({errBlocks: this.errorBlocks})
     const method = get(this.config, 'method');
     if (!method) {
       this.errorMessage = 'No HTTP method provided';

--- a/src/app/blocks/http-block/http-block.component.ts
+++ b/src/app/blocks/http-block/http-block.component.ts
@@ -6,7 +6,6 @@ import { MatLegacySnackBar as MatSnackBar } from '@angular/material/legacy-snack
 import { catchError, expand, reduce, takeWhile } from 'rxjs/operators';
 import { of, EMPTY } from 'rxjs';
 import { mappingUtility } from '../mapping-block/mapping-util';
-
 @Component({
   selector: 'app-http-block',
   templateUrl: './http-block.component.html',
@@ -62,6 +61,7 @@ export class HttpBlockComponent implements OnInit, OnChanges {
       return;
     }
     this.responseType = get(this.config, 'responseType', 'json');
+    console.log({config: this.config})
     this.errorBlocks = get(this.config, 'onError.blocks', []);
     this.makeRequest();
   }
@@ -73,6 +73,8 @@ export class HttpBlockComponent implements OnInit, OnChanges {
   makeRequest() {
     this.hasError = false;
     this.isLoading = true;
+    // this.errorBlocks = [];
+    console.log({errBlocks: this.errorBlocks})
     const method = get(this.config, 'method');
     if (!method) {
       this.errorMessage = 'No HTTP method provided';
@@ -147,9 +149,11 @@ export class HttpBlockComponent implements OnInit, OnChanges {
                 return of({error, hasError: this.hasError, errorMessage: this.errorMessage});
               })
             )
-            .subscribe(response => {
+            .subscribe((response: Record<string, any>) => {
               this.isLoading = false;
               this.hasError = false;
+              if(!response.hasError) this.errorBlocks = [];
+
               this.outputResult(response);
             });
         }
@@ -165,9 +169,11 @@ export class HttpBlockComponent implements OnInit, OnChanges {
               return of({error, hasError: this.hasError, errorMessage: this.errorMessage});
             })
           )
-          .subscribe(response => {
+          .subscribe((response: Record<string, any>) => {
             this.isLoading = false;
             this.hasError = false;
+            if(!response.hasError) this.errorBlocks = [];
+            
             this.outputResult(response);
           });
         break;
@@ -193,9 +199,11 @@ export class HttpBlockComponent implements OnInit, OnChanges {
               return of({error, hasError: this.hasError, errorMessage: this.errorMessage});
             })
           )
-          .subscribe(response => {
+          .subscribe((response: Record<string, any>) => {
             this.isLoading = false;
             this.hasError = false;
+            if(!response.hasError) this.errorBlocks = [];
+
             this.outputResult(response);
             const notify = get(this.config, 'notify', true);
             if (notify) {
@@ -240,9 +248,11 @@ export class HttpBlockComponent implements OnInit, OnChanges {
               return of({error, hasError: this.hasError, errorMessage: this.errorMessage});
             })
           )
-          .subscribe(response => {
+          .subscribe((response: Record<string, any>) => {
             this.isLoading = false;
             this.hasError = false;
+            if(!response.hasError) this.errorBlocks = [];
+
             this.outputResult(response);
             const notify = get(this.config, 'notify', true);
             if (notify) {


### PR DESCRIPTION
Currently, the HTTP block handle error in the code but it does not return any information about it.
If a GET/POST/PUT/... request is made and an error is raised, the data object in the flow is `null`

With this PR the data object in the flow, will now return the error information.
It also contain a very handy `hasError: true` property so it can be easily check for error or not and potentially display error messages in the flow.

Here two screenshots of how the result will be:
![image](https://github.com/kendraio/kendraio-app/assets/1055531/fa432677-f17b-4551-a9d7-0c1547120a38)
![image](https://github.com/kendraio/kendraio-app/assets/1055531/7de47433-5789-4997-8c46-a48dbd819603)

And here is a flow that can be use to test this PR: [Kendraio Harvest Time](https://app.kendra.io/harvest-timesheet/harvestTimesheet)

Linear Issue [K-361](https://linear.app/kendraio/issue/K-361/kendraio-time-flow)
