### PR TITLE
Update documentation - Form Block

### DIFF
--- a/docs/workflow/blocks/form.rst
+++ b/docs/workflow/blocks/form.rst
@@ -44,16 +44,74 @@ not dependent on the form, then it is best to place them before the form in the 
 
 Config init
 -----------
-It can often be beneficial to initialiase the form data by creating a mapping of the default data. 
+The initial configuration will result in an empty form.
+The fields of the form can be populated in two ways: manually writing fields or dynamically generating fields from given data.
 
-.. code-block:: json 
+Here's an example of creating a form by manually writing fields and configuring it:
 
+.. code-block:: json
   {
-    "confirm": false
+    "type": "form",
+    "hasSubmit": "true", 
+    "label": "Click to submit",
+    "jsonSchema": {
+        "type": "object",
+        "properties": {
+            "name": {
+                "type": "string",
+                "title": "Name",
+                "default": ""
+            },
+            "lastname": {
+                "type": "string",
+                "title": "Last name",
+                "default": ""
+            }
+        }
+    },
+    "uiSchema": {}
+}
+
+Dynamic data and field titles
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+To generate fields form given data, the data needs to be in a format readable by the form block.
+It is possible to transform the data into the format that the form expects with the help of a mapping block.
+Is also possible to use generated data to dynamically display the title of a field
+
+.. code-block:: json
+  
+
+  // generated data
+  {
+    "name": `John`,
+    "surname": `Doe`
   }
 
-Examples
----------
+  // Form config
+  {
+    "type": "form",
+    "jsonSchema": {
+        "type": "object",
+        "properties": {
+            "title": {
+                "type": "string",
+                "title": "I am harcoded text"
+            },
+            "user_name": {
+                "type": "string",
+                "title": "name",
+                "default": "The title of this field comes from dynamic data"
+            },
+            "user_surname": {
+                "type": "string",
+                "title": "surname",
+                "default": "The title of this field comes from dynamic data"
+            }
+        }
+    },
+    "uiSchema": {}
+}
+
 
 Read-only
 ^^^^^^^^^
@@ -76,47 +134,6 @@ Display a field in read-only mode (not editable)
     },
     "uiSchema": {}
   }
-
-Form validation
-^^^^^^^^^^^^^^^
-
-Dynamic field title
-^^^^^^^^^^^^^^^^^^^
-Using dynamic data as title for the form field
-
-.. code-block:: json
-  
-
-  // data
-  {
-    "name": `John`,
-    "surname": `Doe`
-  }
-
-  // Form config
-  {
-    "type": "form",
-    "jsonSchema": {
-        "type": "object",
-        "properties": {
-            "title": {
-                "type": "string",
-                "title": "I am harcoded text"
-            },
-            "user_name": {
-                "type": "string",
-                "title": "name",
-                "default": "titlte of this field come from dynamic data"
-            },
-            "user_surname": {
-                "type": "string",
-                "title": "surname",
-                "default": "titlte of this field come from dynamic data"
-            }
-        }
-    },
-    "uiSchema": {}
-}
 
 
 No submit button

--- a/docs/workflow/blocks/form.rst
+++ b/docs/workflow/blocks/form.rst
@@ -44,7 +44,7 @@ not dependent on the form, then it is best to place them before the form in the 
 
 Config init
 -----------
-If can often be beneficial to initialiase the form data by creating an mapping of the default data. 
+It can often be beneficial to initialiase the form data by creating a mapping of the default data. 
 
 .. code-block:: json 
 
@@ -52,13 +52,75 @@ If can often be beneficial to initialiase the form data by creating an mapping o
     "confirm": false
   }
 
-
 Examples
 ---------
 
+Read-only
+^^^^^^^^^
+Display a field in read-only mode (not editable)
+
+.. code-block:: json
+
+  {
+    "type": "form",
+    "label": "Search",
+    "jsonSchema": {
+        "type": "object",
+        "properties": {
+            "name": {
+                "type": "string",
+                "title": "Artist name",
+                "readOnly": true
+            }
+        }
+    },
+    "uiSchema": {}
+  }
+
+Form validation
+^^^^^^^^^^^^^^^
+
+Dynamic field title
+^^^^^^^^^^^^^^^^^^^
+Using dynamic data as title for the form field
+
+.. code-block:: json
+  
+
+  // data
+  {
+    "name": `John`,
+    "surname": `Doe`
+  }
+
+  // Form config
+  {
+    "type": "form",
+    "jsonSchema": {
+        "type": "object",
+        "properties": {
+            "title": {
+                "type": "string",
+                "title": "I am harcoded text"
+            },
+            "user_name": {
+                "type": "string",
+                "title": "name",
+                "default": "titlte of this field come from dynamic data"
+            },
+            "user_surname": {
+                "type": "string",
+                "title": "surname",
+                "default": "titlte of this field come from dynamic data"
+            }
+        }
+    },
+    "uiSchema": {}
+}
+
+
 No submit button
 ^^^^^^^^^^^^^^^^
-
 A simple search form without a submit button. 
 
 .. code-block:: json

--- a/docs/workflow/blocks/mapping.rst
+++ b/docs/workflow/blocks/mapping.rst
@@ -74,6 +74,14 @@ Output will be:
   surname:"Doe"
   iAmNull:null
 
+Is also possible to wrap the whole expression in backtick. The output will be the same:
+
+.. code-block:: json
+  `{
+    "name": "John",
+    "surname": "Doe",
+    "iAmNotNull": "now this value is visible too"
+  }`
 
 
 Not

--- a/docs/workflow/blocks/mapping.rst
+++ b/docs/workflow/blocks/mapping.rst
@@ -53,9 +53,31 @@ read from *filter*. Reading from  *state.global.workflowCloud.listWorkflows.filt
 Handy JMESPath patterns
 -----------------------
 
+Using string as value
+^^^^^^^^^^^^^^^^^^^^
+When manually creating data, a string will be passed as value.
+Usually keys and values are wrapped in double quotes, to be valid JMESPath.
+In the case of an hardcoded string, the value must be wrapped in backtick, otherwise it will result `null`
+
+.. code-block:: json
+  {
+    "name": `John`,
+    "surname": `Doe`,
+    "iAmNull": "not showing"
+  }
+
+Output will be:
+
+.. code-block:: text
+
+  name:"John"
+  surname:"Doe"
+  iAmNull:null
+
+
+
 Not
 ^^^
-
 When your data structuture holds the value that you wish to negate, you need to enclose the 
 path of your data in parentheses before you NOT it. 
 

--- a/docs/workflow/blocks/mapping.rst
+++ b/docs/workflow/blocks/mapping.rst
@@ -53,12 +53,10 @@ read from *filter*. Reading from  *state.global.workflowCloud.listWorkflows.filt
 Handy JMESPath patterns
 -----------------------
 
-Using string as value
-^^^^^^^^^^^^^^^^^^^^
-When manually creating data, a string will be passed as value.
-Usually keys and values are wrapped in double quotes, to be valid JMESPath.
-In the case of an hardcoded string, the value must be wrapped in backtick, otherwise it will result `null`
-
+Using a string as a value
+^^^^^^^^^^^^^^^^^^^^^^^^^
+To be valid JMESPath, keys and values must be wrapped in double quotes.
+For a hardcoded string, the value must be wrapped in backticks, otherwise it will result `null` for undefined variables.
 .. code-block:: json
   {
     "name": `John`,
@@ -70,11 +68,12 @@ Output will be:
 
 .. code-block:: text
 
-  name:"John"
-  surname:"Doe"
-  iAmNull:null
+  name: "John"
+  surname: "Doe"
+  iAmNull: null
 
-Is also possible to wrap the whole expression in backtick. The output will be the same:
+We've seen that property values of object keys can be set using backticks, and it is also possible to wrap a whole JSON object in backticks. 
+The output will be the same as this:
 
 .. code-block:: json
   `{

--- a/docs/workflow/blocks/variable_set.rst
+++ b/docs/workflow/blocks/variable_set.rst
@@ -6,10 +6,10 @@ Save a value to local storage.
 
 Supported properties
 --------------------
-  **name**: The name of the variable 
-   **showNotify** (boolean) (default=true): Display a notification that the variable has been set
-   **nameGetter** : Provide a location for the variable name
-   **valueGetter**: Provide a location for the variable value
+- **name**: The name of the variable 
+- **showNotify** (boolean) (default=true): Display a notification that the variable has been set
+- **nameGetter** : Provide a location for the variable name
+- **valueGetter**: Provide a location for the variable value
 
 
 Default config


### PR DESCRIPTION
Some small but helpful improvements in Kendraio Docs about Form block
- [x] read-only
- [x] example how a value can be used as title
- [x] example value with backticks: set string as value in form/mapping i.e. "type": "string" otherwise it return null i.e - Added to the Mapping doc as it is more general to JMESPath
- [ ] validation

Linear ticket [K-332](https://linear.app/kendraio/issue/K-332/update-form-documentation)