### PR TITLE
Add Run All Specs button to Electron browser

### DIFF
--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -31,5 +31,6 @@ export default defineConfig({
     supportFile: false,
     baseUrl: 'http://localhost:4200',
     specPattern: 'cypress/e2e/**/*.{js,jsx,ts,tsx}',
+    experimentalRunAllSpecs: true
   },
 })


### PR DESCRIPTION
This code change introduces a Run All Specs button to the Electron Browser by adding the setting to cypress.config.ts. This makes our end to end tests much easier to run.