### PR TITLE
Add GitHub Issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,32 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**To Reproduce**
+Steps to reproduce the behaviour:
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error
+
+**Expected behaviour**
+A clear and concise description of what you expected to happen.
+
+
+**Please provide information that may help reproduce the issue, as best you can:**
+ - OS: [e.g. Ubuntu]
+ - Browser [e.g. Firefox 121.0.1, Chrome, safari]
+ - App version
+- Angular Version (If known)
+- A screenshot showing your problem.
+
+**Additional context**
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -7,35 +7,31 @@ assignees: ''
 
 ---
 
-**Describe the bug**
-A clear and concise description of what the bug is.
+**Bug description**
+<!-- A clear and concise description of what the bug is. -->
 
-**To Reproduce**
-Steps to reproduce the behaviour, e.g:
+**Reproduction steps**
+<!-- Provide steps to reproduce the behaviour, e.g: -->
 1. Go to '...'
 2. Click on '....'
 3. Scroll down to '....'
 4. See error
 
 **Expected behaviour**
-Explain clearly and simply what you expected to happen instead of the bug.
+<!-- Explain clearly and simply what you expected to happen instead of the bug. -->
 
 **Visuals**
-- **Screenshots**: Please include a screenshot showing the problem.
-- **Video**: If possible, a short video can be really helpful in understanding the issue, especially for dynamic or interactive bugs.
+<!-- Screenshot and / or short video can be really helpful in understanding the issue, especially for dynamic or interactive bugs. -->
 
-**Flow Specific Information (for bugs in Flows)**
-- **Flow Configuration as JSON**: Please include your flow's JSON configuration. This is crucial for diagnosing issues with flows.
-- **Shared Link to Flow**: Consider providing a shared link to your flow configuration. This makes it easier to replicate and understand the issue. For guidance on sharing, check [here](https://kendraio-app.readthedocs.io/en/latest/workflow/sharing.html).
+**Flow Configuration**: <!-- To help diagnose issues with Flows, the flow's JSON configuration or a shared link to the Flow makes it easier to replicate and understand the issue. For ways to share flows see: https://kendraio-app.readthedocs.io/en/latest/workflow/sharing.html -->
 
-**Technical Details**
-- OS: [e.g. Ubuntu]
-- Browser: [e.g. Firefox 123, Chrome 45, Safari 67]
-- App version
-- Angular Version (if known)
+**Runtime environment:**
+- OS: <!-- [e.g. Ubuntu] -->
+- Browser: <!-- [e.g. Firefox 123, Chrome 45, Safari 67] -->
+- App version:
+- Angular Version: <!-- (if known) -->
 
-**Additional context**
-Add any other context about the problem here.
+**Additional context:**
+<!--Add any other context about the problem here. -->
 
-**Label Tags**
-- Please check for and apply label tags that match the issue type, e.g., use 'state' tag for state reactivity bugs.
+<!--- Please check for label tags that match the issue type, e.g., use 'state' tag for state reactivity bugs. -->

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -11,22 +11,31 @@ assignees: ''
 A clear and concise description of what the bug is.
 
 **To Reproduce**
-Steps to reproduce the behaviour:
+Steps to reproduce the behaviour, e.g:
 1. Go to '...'
 2. Click on '....'
 3. Scroll down to '....'
 4. See error
 
 **Expected behaviour**
-A clear and concise description of what you expected to happen.
+Explain clearly and simply what you expected to happen instead of the bug.
 
+**Visuals**
+- **Screenshots**: Please include a screenshot showing the problem.
+- **Video**: If possible, a short video can be really helpful in understanding the issue, especially for dynamic or interactive bugs.
 
-**Please provide information that may help reproduce the issue, as best you can:**
- - OS: [e.g. Ubuntu]
- - Browser [e.g. Firefox 121.0.1, Chrome, safari]
- - App version
-- Angular Version (If known)
-- A screenshot showing your problem.
+**Flow Specific Information (for bugs in Flows)**
+- **Flow Configuration as JSON**: Please include your flow's JSON configuration. This is crucial for diagnosing issues with flows.
+- **Shared Link to Flow**: Consider providing a shared link to your flow configuration. This makes it easier to replicate and understand the issue. For guidance on sharing, check [here](https://kendraio-app.readthedocs.io/en/latest/workflow/sharing.html).
+
+**Technical Details**
+- OS: [e.g. Ubuntu]
+- Browser: [e.g. Firefox 123, Chrome 45, Safari 67]
+- App version
+- Angular Version (if known)
 
 **Additional context**
 Add any other context about the problem here.
+
+**Label Tags**
+- Please check for and apply label tags that match the issue type, e.g., use 'state' tag for state reactivity bugs.

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -10,6 +10,8 @@ assignees: ''
 **Bug description**
 <!-- A clear and concise description of what the bug is. -->
 
+<!-- Screenshot and / or short video can be really helpful in understanding the issue, especially for dynamic or interactive bugs. -->
+
 **Reproduction steps**
 <!-- Provide steps to reproduce the behaviour, e.g: -->
 1. Go to '...'
@@ -20,18 +22,15 @@ assignees: ''
 **Expected behaviour**
 <!-- Explain clearly and simply what you expected to happen instead of the bug. -->
 
-**Visuals**
-<!-- Screenshot and / or short video can be really helpful in understanding the issue, especially for dynamic or interactive bugs. -->
+**Flow Configuration** <!-- To help diagnose issues with Flows, the flow's JSON configuration or a shared link to the Flow makes it easier to replicate and understand the issue. For ways to share flows see: https://kendraio-app.readthedocs.io/en/latest/workflow/sharing.html -->
 
-**Flow Configuration**: <!-- To help diagnose issues with Flows, the flow's JSON configuration or a shared link to the Flow makes it easier to replicate and understand the issue. For ways to share flows see: https://kendraio-app.readthedocs.io/en/latest/workflow/sharing.html -->
-
-**Runtime environment:**
+**Runtime environment**
 - OS: <!-- [e.g. Ubuntu] -->
 - Browser: <!-- [e.g. Firefox 123, Chrome 45, Safari 67] -->
 - App version:
 - Angular Version: <!-- (if known) -->
 
-**Additional context:**
+**Additional context**
 <!--Add any other context about the problem here. -->
 
 <!--- Please check for label tags that match the issue type, e.g., use 'state' tag for state reactivity bugs. -->


### PR DESCRIPTION
Adds a template to help ensure we capture key details so we can reproduce them, know how important problems are, and so on.