### PR TITLE
Cypress: Remove force:true from click 

### DIFF
--- a/cypress/e2e/gosub.ts
+++ b/cypress/e2e/gosub.ts
@@ -24,7 +24,7 @@ describe('Subroutine workflow block', () => {
                 "workflowId": "madeUpFlowIDA"
             }
         ]);
-        cy.get('mat-toolbar > button mat-icon').contains('settings').click({force: true});
+        cy.get('[data-cy="toolbar-setting-button"]').click();
         cy.get("#mat-expansion-panel-header-0").click();
         // cy.pause();
         cy.get("#mat-input-0")

--- a/cypress/e2e/share.ts
+++ b/cypress/e2e/share.ts
@@ -36,9 +36,9 @@ describe('Share functionality', () => {
         cy.contains('Rishi');
 
         // Now we press the share button, and select share database:
-        cy.get('mat-icon').contains("settings").click({force: true});
-        cy.get('mat-icon').contains("share").click({force: true});
-        cy.get('button:contains("Share database")').click({force: true});
+        cy.get('[data-cy="toolbar-setting-button"]').click();
+        cy.get('[data-cy="sidenav-share-button"]').click();
+        cy.get('[data-cy="dialog-share-shareDatabase"]').click();
 
         // assert shareValue is in the databaseUrl
         cy.get('app-show-share-link-dialog textarea').should('contain', databaseUrl);

--- a/cypress/e2e/spec.ts
+++ b/cypress/e2e/spec.ts
@@ -51,12 +51,12 @@ describe('workspace-project App', () => {
     cy.get('app-root mat-toolbar').contains('menu').click();
     cy.contains('Flow Builder').click();
     cy.contains('settings');
-    cy.get('mat-toolbar > button mat-icon').contains('settings').click({force: true});
+    cy.get('[data-cy="toolbar-setting-button"]').click();
     cy.get('app-workflow-sidenav').contains('delete_forever').click().get('app-workflow-sidenav').contains('Mapping').should('not.exist');
-    cy.get('app-workflow-sidenav').contains('Add Task').click({force: true});
+    cy.get('[data-cy="blocks-editor-add-task"]').click();
     cy.contains('Select Task');
     cy.get('mat-dialog-container').contains('Mapping').click();
-    cy.get('button').contains('Add Task').click({force: true});
+    cy.get('[data-cy="dialog-addBlock-addTask-button"]').click();
     cy.get('button').contains('Mapping');
   });
 
@@ -69,7 +69,7 @@ describe('workspace-project App', () => {
         "blockComment": "testingComment",
       }
     ]);
-    cy.get('mat-toolbar > button > mat-icon').contains('settings').click({force: true});
+    cy.get('[data-cy="toolbar-setting-button"]').click();
     cy.get('app-workflow-sidenav').contains('testingComment').should('exist');
     cy.get('app-workflow-sidenav').contains('testingComment').click();  
     // cy.get('app-workflow-sidenav').contains('Block Comment'); // FIXME: regression - MatFormField placeholder text is not visible
@@ -83,7 +83,7 @@ describe('workspace-project App', () => {
         "blockComment": "testingComment first line\nComment line2",
       }
     ]);
-    cy.get('mat-toolbar > button mat-icon').contains('settings').click({force: true});
+    cy.get('[data-cy="toolbar-setting-button"]').click();
     cy.get('app-workflow-sidenav').contains('testingComment').should('exist');
     cy.get('app-workflow-sidenav').contains('line2').should('not.exist');
     cy.get('app-workflow-sidenav').contains('testingComment').click();

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -40,13 +40,15 @@
   <ng-container *ngIf="pageTitle$ | async as pageTitleData">
       <button mat-icon-button
               (click)="blocksSidePane.close()"
-              *ngIf="blocksSidePane.opened">
+              *ngIf="blocksSidePane.opened"
+              data-cy="toolbar-setting-button">
         <mat-icon>settings</mat-icon>
       </button>
       <button mat-icon-button
               (click)="blocksSidePane.open()"
               [disabled]="!pageTitleData.isWorkflow"
-              *ngIf="!blocksSidePane.opened">
+              *ngIf="!blocksSidePane.opened"
+              data-cy="toolbar-setting-button">
         <mat-icon>settings</mat-icon>
       </button>
   </ng-container>

--- a/src/app/components/blocks-editor/blocks-editor.component.html
+++ b/src/app/components/blocks-editor/blocks-editor.component.html
@@ -1,4 +1,3 @@
-
 <mat-accordion cdkDropList (cdkDropListDropped)="drop($event)">
   <mat-expansion-panel *ngFor="let block of blocks; let i = index" cdkDrag>
     <mat-expansion-panel-header>
@@ -115,7 +114,7 @@
 </mat-accordion>
 
 <br>
-<button mat-flat-button (click)="addBlock()">
+<button mat-flat-button (click)="addBlock()" data-cy="blocks-editor-add-task">
   <mat-icon>add</mat-icon>
   <span class="button-label">Add Task</span>
 </button>

--- a/src/app/components/workflow-sidenav/workflow-sidenav.component.html
+++ b/src/app/components/workflow-sidenav/workflow-sidenav.component.html
@@ -10,7 +10,7 @@
 <!--     = <button type="button" mat-icon-button (click)="workflow.clearWorkflowData()" matTooltip="Clear workflow data">-->
 <!--        <app-kendraio-icon icon="fa-eraser"></app-kendraio-icon>-->
 <!--      </button>-->
-      <button type="button" mat-icon-button (click)="workflow.shareConfig()" matTooltip="Share">
+      <button type="button" mat-icon-button (click)="workflow.shareConfig()" matTooltip="Share" data-cy="sidenav-share-button">
         <mat-icon>share</mat-icon>
       </button>
       <button type="button" mat-icon-button (click)="workflow.loadFromAdapter()" matTooltip="Load from Adapter">

--- a/src/app/dialogs/add-block-dialog/add-block-dialog.component.html
+++ b/src/app/dialogs/add-block-dialog/add-block-dialog.component.html
@@ -23,6 +23,8 @@
 </div>
 
 <div mat-dialog-actions class="dialog-buttons">
-  <button mat-flat-button (click)="addBlock()" color="primary" [disabled]="!selectedBlockType">Add Task</button>
+  <button mat-flat-button (click)="addBlock()" color="primary" [disabled]="!selectedBlockType" data-cy="dialog-addBlock-addTask-button">
+    Add Task
+  </button>
   <button mat-flat-button (click)="cancel()" cdkFocusInitial>Cancel</button>
 </div>

--- a/src/app/dialogs/show-share-link-dialog/show-share-link-dialog.component.html
+++ b/src/app/dialogs/show-share-link-dialog/show-share-link-dialog.component.html
@@ -1,6 +1,6 @@
 <mat-dialog-actions>
   <button mat-flat-button (click)="shareMode='flow'">Share flow</button>
-  <button mat-flat-button (click)="shareMode='database'">Share database</button>
+  <button mat-flat-button (click)="shareMode='database'" data-cy="dialog-share-shareDatabase">Share database</button>
 </mat-dialog-actions>
 
 <div *ngIf="shareMode=='flow'">


### PR DESCRIPTION
This PR take care of the task: `Review tests, are force clicks needed with new Cypress version?` from[ Angular 16 Issue](https://github.com/kendraio/kendraio-app/issues/440)

`force:click` is [a functionality of Cypress ](https://docs.cypress.io/api/commands/click#Options) and is present in all the versions. 
It is used when an element needs to be clicked, but it is hidden by another element. (For example, a menu that shows up when user over on another element)
As per [documentation](https://docs.cypress.io/guides/references/error-messages#Ignore-built-in-error-checking) and best practice, we should not overuse it: 
> Be careful with this option. It's possible to force your tests to pass when the element is actually not interactable in your application.

To avoid using it, there is no one-solution-fit-all, every situation must be evaluated differently. 
In our case, Cypress covers some material UI element with an invisible element like focus. Therefore, is enough to use a specific HTML attribute to target the element to be clicked. 
A `data-cy` attribute was added to the HTML element, so Cypress can easily spot the element to click, even if is hidden by other elements.
