### PR TITLE
Documentation fix: Mapping Block `now` function uses RFC 7231 not ISO 8601

### DIFF
--- a/docs/workflow/blocks/mapping.rst
+++ b/docs/workflow/blocks/mapping.rst
@@ -417,7 +417,7 @@ Examples:
 10. now
 ------
 
-Returns the current UTC timestamp in ISO 8601 format.
+Returns the current UTC timestamp in RFC 7231 format.
 
 Examples:
 


### PR DESCRIPTION
See https://github.com/kendraio/kendraio-app/issues/465 for more info.