### PR TITLE
Coil Web Monetization event simulation feature

### DIFF
--- a/src/app/blocks/web-money/web-money.component.ts
+++ b/src/app/blocks/web-money/web-money.component.ts
@@ -271,9 +271,26 @@ export class WebMoneyComponent extends BaseBlockComponent {
       }
 
     }
-    if (document['monetization']) {
-      document['monetization'].addEventListener('monetizationprogress', monetizationprogressHandler);
+
+    // Coil's web monetization API is down because they have stopped their service.
+    //
+    //if (document['monetization']) {
+    //  document['monetization'].addEventListener('monetizationprogress', monetizationprogressHandler);
+    //}
+    
+    // We are using a mock event to simulate the web monetization progress event:
+    function dispatchMockMonetizationProgressEvent() {
+      monetizationprogressHandler({
+        detail: {
+          amount: '1', 
+          assetCode: 'XRP', 
+          assetScale: 2,
+        },
+      });
     }
+    
+    setInterval(dispatchMockMonetizationProgressEvent, 1000);
+
   }
 
   onData(data: any, _firstChange: boolean) {

--- a/src/app/blocks/web-money/web-money.component.ts
+++ b/src/app/blocks/web-money/web-money.component.ts
@@ -273,11 +273,6 @@ export class WebMoneyComponent extends BaseBlockComponent {
     }
 
     // Coil's web monetization API is down because they have stopped their service.
-    //
-    //if (document['monetization']) {
-    //  document['monetization'].addEventListener('monetizationprogress', monetizationprogressHandler);
-    //}
-    
     // We are using a mock event to simulate the web monetization progress event:
     function dispatchMockMonetizationProgressEvent() {
       monetizationprogressHandler({


### PR DESCRIPTION
Uses a timer to emulate Web Monetization events since Coil have stopped their service.
It's for use by the Web Money block, along side the Player block for sending music statistics to "DSP-1" / "Distributor".

Please note that https://kendraio-app-git-player-statistics-kendraio.vercel.app/player/all does not play because of a CORS issue but will when ran via localhost. When ran there will be network events when audio is playing.

Testing example:
1. You can locally build, and run the server.
2. Look at existing state of the stats here: http://localhost:4200/dsp1/myStats
3. In a new tab, play a track from: http://localhost:4200/player/all
4. In another tab, a few seconds later, you can load http://localhost:4200/dsp1/myStats again and should see that the statistics page has updated.
