### PR TITLE
Upgrades Cypress container to 14.5.1

### DIFF
--- a/.github/actions/tests/Dockerfile
+++ b/.github/actions/tests/Dockerfile
@@ -1,15 +1,7 @@
-FROM cypress/included:8.4.1
-
-# Install Node 18
-RUN curl -fsSL https://deb.nodesource.com/setup_18.x | bash - && \
-    apt-get install -y nodejs && \
-    mv /usr/local/bin/node /usr/local/bin/node_old && \
-    ln -s /usr/bin/node /usr/local/bin/node && \
-    npm install -g npm@latest && \
-    node --version && npm --version
+FROM cypress/included:14.5.1
 
 # https://docs.cypress.io/guides/continuous-integration/introduction#Machine-requirements
-RUN apt-get update && apt-get install -y curl jq
+RUN apt-get update && apt-get install -y curl jq xauth
 # Copies your code file from your action repository to the filesystem path `/` of the container
 COPY entrypoint.sh /entrypoint.sh
 


### PR DESCRIPTION
**Fixes broken tests caused by old Cypress container**

Our GitHub Actions tests started failing because the Cypress Docker image was based on Debian Buster, which has reached end-of-life, and the package repositories are no longer readily accessible.
The container runs our unit tests and the end-to-end Cypress tests.
This upgrades the container from `cypress/included:8.4.1` to `cypress/included:14.5.1`, which uses a supported Debian version and already includes Node.js v22.17.

**Changes:**
- Upgrades Cypress container to 14.5.1
- Removed redundant Node.js 18 installation (now included)
- Added `xauth` package (required but no longer bundled)

Fixes #544