### PR TITLE
Allow Mapping Block json() util to take arguments

### DIFF
--- a/docs/workflow/blocks/mapping.rst
+++ b/docs/workflow/blocks/mapping.rst
@@ -609,6 +609,16 @@ Use json-stringify-safe to safely stringify and accept arguments for replacer an
 Examples:
 
 .. code-block:: javascript
+
+   json({
+      "name": "Alice",
+      "tags": [
+         "dev",
+         "ui"
+      ]
+   })
+
+   // Output on one line: "{{"name": "Alice","tags": ["dev","ui"]}"
    
    json({
       "name": "Alice",
@@ -618,7 +628,7 @@ Examples:
       ]
    }, null, '2')
 
-   // Output: "{
+   // Output prettified: "{
 .. {
 ..   "name": "Alice",
 ..   "tags": [
@@ -626,6 +636,12 @@ Examples:
 ..     "ui"
 ..   ]
 .. }"
+  
+   In order to render a prettified JSON, the data must be in a <pre> and <code> tags
+   i.e. 
+
+   <code><pre>{{data}}</code></pre>
+
 
 
 22. jsonParse

--- a/docs/workflow/blocks/mapping.rst
+++ b/docs/workflow/blocks/mapping.rst
@@ -296,18 +296,17 @@ Available Extensions
 20. debug
 21. json
 22. jsonParse
-23. jsonStringify
-24. markdown
-25. btoa
-26. base64encode
-27. pairwise
-28. numDiff
-29. percentChange
-20. groupByKeys
-31. all
-32. parseDate
-33. parseDuration
-34. parseUnixTimestamp
+23. markdown
+24. btoa
+25. base64encode
+26. pairwise
+27. numDiff
+28. percentChange
+29. groupByKeys
+30. all
+31. parseDate
+32. parseDuration
+33. parseUnixTimestamp
 
 Each of these extensions is detailed below with example usages.
 

--- a/docs/workflow/blocks/mapping.rst
+++ b/docs/workflow/blocks/mapping.rst
@@ -296,17 +296,18 @@ Available Extensions
 20. debug
 21. json
 22. jsonParse
-23. markdown
-24. btoa
-25. base64encode
-26. pairwise
-27. numDiff
-28. percentChange
-29. groupByKeys
-30. all
-31. parseDate
-32. parseDuration
-33. parseUnixTimestamp
+23. jsonStringify
+24. markdown
+25. btoa
+26. base64encode
+27. pairwise
+28. numDiff
+29. percentChange
+20. groupByKeys
+31. all
+32. parseDate
+33. parseDuration
+34. parseUnixTimestamp
 
 Each of these extensions is detailed below with example usages.
 
@@ -620,7 +621,7 @@ Examples:
 
 .. code-block:: javascript
    
-   jsonParse(data)
+   jsonParse(data) // where data is a string of valid JSON
 
    { 
       name: "John Doe", 
@@ -630,7 +631,26 @@ Examples:
       projects: [{ id: 1, title: "Project A" },{ id: 2, title: "Project B" }] 
    }
 
-23. markdown
+23. jsonStringify
+--------
+
+Converts a JavaScript object into a JSON string.
+
+Examples:
+
+.. code-block:: javascript
+   
+   jsonParse(data) // where data is an object
+
+   { 
+      name: "John Doe", 
+      age: 35, 
+      email: "john.doe@example.com", 
+      tags: ["frontend","ui"], 
+      projects: [{ id: 1, title: "Project A" },{ id: 2, title: "Project B" }] 
+   }
+
+24. markdown
 ------------
 
 Converts a markdown string to HTML.
@@ -641,7 +661,7 @@ Examples:
 
    markdown('## Header')  // Output: "<h2 id=\"header\">Header</h2>"
 
-24. btoa
+25. btoa
 ---------
 
 Encodes a string in base-64.
@@ -652,7 +672,7 @@ Examples:
 
    btoa(data.name)  // Output: "Sm9obiBEb2U="
 
-25. base64encode
+26. base64encode
 ----------------
 
 Safely encodes a string in base-64.
@@ -663,7 +683,7 @@ Examples:
 
    base64encode(data.name)  // Output: "Sm9obiBEb2U="
 
-26. pairwise
+27. pairwise
 ------------
 
 Groups the elements of an array into pairs. The function outputs an array containing objects, where each object consists of two properties: "current" and "next". The "current" property refers to the current element of the input array, while the "next" property refers to the next element in the input array. If there is no next element, the "next" property will be set to null.
@@ -699,7 +719,7 @@ Output:
         }
     ]
 
-27. numDiff
+28. numDiff
 -----------
 
 Subtracts two numbers.
@@ -710,7 +730,7 @@ Subtracts two numbers.
 
 Output: 1
 
-28. percentChange
+29. percentChange
 -----------------
 
 Calculates the percent change between two numbers.
@@ -721,7 +741,7 @@ Calculates the percent change between two numbers.
 
 Output: 100
 
-29. groupByKeys
+30. groupByKeys
 ----------------
 
 Groups the values of an array of objects by key.
@@ -745,7 +765,7 @@ Output:
         ]
     }
 
-30. all
+31. all
 -------
 
 Checks if all elements in an array pass a test (i.e., are truthy).
@@ -762,7 +782,7 @@ Output: true
 
 Output: false
 
-31. parseDate
+32. parseDate
 -------------
 
 Parses a date string in various formats and returns a date string.
@@ -773,7 +793,7 @@ Parses a date string in various formats and returns a date string.
 
 Output: "2020-01-01T00:00:00.000+00:00"
 
-32. parseDuration
+33. parseDuration
 -----------------
 
 Parses a duration string and returns the number of seconds.
@@ -784,7 +804,7 @@ Parses a duration string and returns the number of seconds.
 
 Output: "6030"
 
-33. parseUnixTimestamp
+34. parseUnixTimestamp
 ----------------------
 
 Parses a Unix timestamp and returns an ISO 8601 date string.

--- a/docs/workflow/blocks/mapping.rst
+++ b/docs/workflow/blocks/mapping.rst
@@ -604,17 +604,32 @@ Examples:
 --------
 
 Converts a value to a JSON string.
+Use json-stringify-safe to safely stringify and accept arguments for replacer and space.
 
 Examples:
 
 .. code-block:: javascript
    
-   json(data)
+   json({
+      "name": "Alice",
+      "tags": [
+         "dev",
+         "ui"
+      ]
+   }, null, '2')
 
-   // Output: "{\"name\":\"John Doe\",\"age\":35,\"email\":\"john.doe@example.com\",\"tags\":[\"frontend\",\"ui\"],\"projects\":[{\"id\":1,\"title\":\"Project A\"},{\"id\":2,\"title\":\"Project B\"}]}"
+   // Output: "{
+.. {
+..   "name": "Alice",
+..   "tags": [
+..     "dev",
+..     "ui"
+..   ]
+.. }"
+
 
 22. jsonParse
---------
+-------------
 
 Converts a JSON string to a JS Object.
 
@@ -632,26 +647,7 @@ Examples:
       projects: [{ id: 1, title: "Project A" },{ id: 2, title: "Project B" }] 
    }
 
-23. jsonStringify
---------
-
-Converts a JavaScript object into a JSON string.
-
-Examples:
-
-.. code-block:: javascript
-   
-   jsonParse(data) // where data is an object
-
-   { 
-      name: "John Doe", 
-      age: 35, 
-      email: "john.doe@example.com", 
-      tags: ["frontend","ui"], 
-      projects: [{ id: 1, title: "Project A" },{ id: 2, title: "Project B" }] 
-   }
-
-24. markdown
+23. markdown
 ------------
 
 Converts a markdown string to HTML.
@@ -662,7 +658,7 @@ Examples:
 
    markdown('## Header')  // Output: "<h2 id=\"header\">Header</h2>"
 
-25. btoa
+24. btoa
 ---------
 
 Encodes a string in base-64.
@@ -673,7 +669,7 @@ Examples:
 
    btoa(data.name)  // Output: "Sm9obiBEb2U="
 
-26. base64encode
+25. base64encode
 ----------------
 
 Safely encodes a string in base-64.
@@ -684,7 +680,7 @@ Examples:
 
    base64encode(data.name)  // Output: "Sm9obiBEb2U="
 
-27. pairwise
+26. pairwise
 ------------
 
 Groups the elements of an array into pairs. The function outputs an array containing objects, where each object consists of two properties: "current" and "next". The "current" property refers to the current element of the input array, while the "next" property refers to the next element in the input array. If there is no next element, the "next" property will be set to null.
@@ -720,7 +716,7 @@ Output:
         }
     ]
 
-28. numDiff
+27. numDiff
 -----------
 
 Subtracts two numbers.
@@ -731,7 +727,7 @@ Subtracts two numbers.
 
 Output: 1
 
-29. percentChange
+28. percentChange
 -----------------
 
 Calculates the percent change between two numbers.
@@ -742,7 +738,7 @@ Calculates the percent change between two numbers.
 
 Output: 100
 
-30. groupByKeys
+29. groupByKeys
 ----------------
 
 Groups the values of an array of objects by key.
@@ -766,7 +762,7 @@ Output:
         ]
     }
 
-31. all
+30. all
 -------
 
 Checks if all elements in an array pass a test (i.e., are truthy).
@@ -783,7 +779,7 @@ Output: true
 
 Output: false
 
-32. parseDate
+31. parseDate
 -------------
 
 Parses a date string in various formats and returns a date string.
@@ -794,7 +790,7 @@ Parses a date string in various formats and returns a date string.
 
 Output: "2020-01-01T00:00:00.000+00:00"
 
-33. parseDuration
+32. parseDuration
 -----------------
 
 Parses a duration string and returns the number of seconds.
@@ -805,7 +801,7 @@ Parses a duration string and returns the number of seconds.
 
 Output: "6030"
 
-34. parseUnixTimestamp
+33. parseUnixTimestamp
 ----------------------
 
 Parses a Unix timestamp and returns an ISO 8601 date string.

--- a/docs/workflow/blocks/mapping.rst
+++ b/docs/workflow/blocks/mapping.rst
@@ -536,9 +536,9 @@ Examples:
 
 .. code-block:: javascript
 
-   qs({ name: "Alice", tags: ["dev", "ui"] })
+   qs(data)
    
-   // Output: "name=Alice&tags[0]=dev&tags[1]=ui"
+   // Output: "name=John%20Doe&age=35&email=john.doe%40example.com&tags%5B0%5D=frontend&tags%5B1%5D=ui&projects%5B0%5D%5Bid%5D=1&projects%5B0%5D%5Btitle%5D=Project%20A&projects%5B1%5D%5Bid%5D=2&projects%5B1%5D%5Btitle%5D=Project%20B"
 
 18. parseQs
 -----------
@@ -609,32 +609,24 @@ Examples:
 
 .. code-block:: javascript
 
-   json({
-      "name": "Alice",
-      "tags": [
-         "dev",
-         "ui"
-      ]
-   })
+   json(data)
 
-   // Output on one line: "{{"name": "Alice","tags": ["dev","ui"]}"
+   // Output on one line: "{"name":"John Doe","age":35,"email":"john.doe@example.com","tags":["frontend","ui"],"projects":[{"id":1,"title":"Project A"},{"id":2,"title":"Project B"}]}"
+
    
-   json({
-      "name": "Alice",
-      "tags": [
-         "dev",
-         "ui"
-      ]
-   }, null, '2')
+   json(data, null, '2')
 
-   // Output prettified: "{
-.. {
-..   "name": "Alice",
-..   "tags": [
-..     "dev",
-..     "ui"
-..   ]
-.. }"
+   // Output prettified:
+   // "{
+   //    name: "John Doe",
+   //    age: 35,
+   //    email: "john.doe@example.com",
+   //    tags: ["frontend", "ui"],
+   //    projects: [
+   //       { id: 1, title: "Project A" },
+   //       { id: 2, title: "Project B" }
+   //    ]
+   // }"
   
    In order to render a prettified JSON, the data must be in a <pre> and <code> tags
    i.e. 

--- a/docs/workflow/blocks/mapping.rst
+++ b/docs/workflow/blocks/mapping.rst
@@ -530,15 +530,16 @@ Examples:
 17. qs
 ------
 
-Stringifies an object into a query string.
+Converts a JS object into a URL query string using qs.stringify.
+It output a compact, one-line format (no indentation, not human-readable) string.
 
 Examples:
 
 .. code-block:: javascript
 
-   qs(data)
-
-   // Output: "name=John%20Doe&age=35&email=john.doe%40example.com&tags%5B0%5D=frontend&tags%5B1%5D=ui&projects%5B0%5D%5Bid%5D=1&projects%5B0%5D%5Btitle%5D=Project%20A&projects%5B1%5D%5Bid%5D=2&projects%5B1%5D%5Btitle%5D=Project%20B"
+   qs({ name: "Alice", tags: ["dev", "ui"] })
+   
+   // Output: "name=Alice&tags[0]=dev&tags[1]=ui"
 
 18. parseQs
 -----------

--- a/src/app/blocks/mapping-block/mapping-util.spec.ts
+++ b/src/app/blocks/mapping-block/mapping-util.spec.ts
@@ -94,4 +94,12 @@ describe('MappingUtil', () => {
 
     expect(mappingUtility(data, expr)).toEqual(expected);
   });
+
+  it('should stringify an object into a prettified JSON string', () => {
+    const data = { obj: { name: "Alice", age: 30 } };
+    const expr = 'jsonStringify(obj, null, 2)';
+    const expected = `{\n  "name": "Alice",\n  "age": 30\n}`;
+
+    expect(mappingUtility(data, expr)).toEqual(expected);
+  });
 });

--- a/src/app/blocks/mapping-block/mapping-util.spec.ts
+++ b/src/app/blocks/mapping-block/mapping-util.spec.ts
@@ -87,6 +87,18 @@ describe('MappingUtil', () => {
     expect(mappingUtility(data, expr)).toBe(expected);
   });
 
+  it('should stringify correctly when replacer and space are undefined', () => {
+    const data = {
+      data: { name: "Alice", age: 30, job: "Engineer" }
+    };
+
+    const expr = "json(data)";
+    const expected = JSON.stringify(data.data);
+
+    expect(mappingUtility(data, expr)).toBe(expected);
+  });
+
+
   it('should stringify a JSON object with pretty formatting using space argument', () => {
     const data = {
       data: { name: "Alice", age: 30, job: "Engineer" }

--- a/src/app/blocks/mapping-block/mapping-util.spec.ts
+++ b/src/app/blocks/mapping-block/mapping-util.spec.ts
@@ -87,6 +87,18 @@ describe('MappingUtil', () => {
     expect(mappingUtility(data, expr)).toBe(expected);
   });
 
+  it('should stringify a JSON object with pretty formatting using space argument', () => {
+    const data = {
+      data: { name: "Alice", age: 30, job: "Engineer" }
+    };
+
+    // Use null as replacer and '2' as space (string)
+    const expr = "json(data, null, '2')";
+    const expected = JSON.stringify(data.data, null, 2);
+
+    expect(mappingUtility(data, expr)).toBe(expected);
+  });
+
   it('should parse a valid JSON string into an object', () => {
     const data = { jsonString: '{"name": "Alice", "age": 30}' };
     const expr = "jsonParse(jsonString)";
@@ -95,11 +107,4 @@ describe('MappingUtil', () => {
     expect(mappingUtility(data, expr)).toEqual(expected);
   });
 
-  it('should stringify an object into a prettified JSON string', () => {
-    const data = { obj: { name: "Alice", age: 30 } };
-    const expr = 'jsonStringify(obj)';
-    const expected = `{\n  "name": "Alice",\n  "age": 30\n}`;
-
-    expect(mappingUtility(data, expr)).toEqual(expected);
-  });
 });

--- a/src/app/blocks/mapping-block/mapping-util.spec.ts
+++ b/src/app/blocks/mapping-block/mapping-util.spec.ts
@@ -97,7 +97,7 @@ describe('MappingUtil', () => {
 
   it('should stringify an object into a prettified JSON string', () => {
     const data = { obj: { name: "Alice", age: 30 } };
-    const expr = 'jsonStringify(obj, null, 2)';
+    const expr = 'jsonStringify(obj)';
     const expected = `{\n  "name": "Alice",\n  "age": 30\n}`;
 
     expect(mappingUtility(data, expr)).toEqual(expected);

--- a/src/app/blocks/mapping-block/mapping-util.ts
+++ b/src/app/blocks/mapping-block/mapping-util.ts
@@ -121,6 +121,10 @@ const search = decorate({
     _func: ([v]) => JSON.parse(v),
     _signature: [{types: [TYPE_STRING]}]
   },
+  jsonStringify: {
+    _func: ([v]) => JSON.stringify(v, null, 2),
+    _signature: [{types: [TYPE_STRING]}]
+  },
   markdown: {
     _func: ([s]) => {
       showdown.setFlavor('github');

--- a/src/app/blocks/mapping-block/mapping-util.ts
+++ b/src/app/blocks/mapping-block/mapping-util.ts
@@ -123,7 +123,7 @@ const search = decorate({
   },
   jsonStringify: {
     _func: ([v]) => JSON.stringify(v, null, 2),
-    _signature: [{types: [TYPE_STRING]}]
+    _signature: [{types: [TYPE_OBJECT, TYPE_ARRAY, TYPE_ANY]}]
   },
   markdown: {
     _func: ([s]) => {

--- a/src/app/blocks/mapping-block/mapping-util.ts
+++ b/src/app/blocks/mapping-block/mapping-util.ts
@@ -113,21 +113,21 @@ const search = decorate({
     },
     _signature: [{types: [TYPE_ANY]}]
   },
-  json: {
-    _func: ([v]) => stringify(v),
-    _signature: [{types: [TYPE_ANY]}]
+    json: {
+    _func: ([value, replacer = null, space = undefined]) => {
+      const safeSpace =
+        typeof space === 'string' ? parseInt(space, 10) || space : space;
+      return stringify(value, replacer, safeSpace);
+    },
+    _signature: [
+      { types: [TYPE_ANY] },
+      { optional: true, types: [TYPE_NULL, TYPE_ARRAY] },
+      { optional: true, types: [TYPE_NUMBER, TYPE_STRING] }
+    ]
   },
   jsonParse: {
     _func: ([v]) => JSON.parse(v),
     _signature: [{types: [TYPE_STRING]}]
-  },
-  jsonStringify: {
-    _func: ([value, replacer = null, space = 2]) => JSON.stringify(value, replacer, space),
-    _signature: [
-      { types: [TYPE_OBJECT, TYPE_ARRAY, TYPE_ANY] },  // value
-      { optional: true, types: [TYPE_NULL, TYPE_ARRAY] }, // replacer
-      { optional: true, types: [TYPE_NUMBER, TYPE_STRING] } // space
-    ]
   },
   markdown: {
     _func: ([s]) => {

--- a/src/app/blocks/mapping-block/mapping-util.ts
+++ b/src/app/blocks/mapping-block/mapping-util.ts
@@ -122,8 +122,12 @@ const search = decorate({
     _signature: [{types: [TYPE_STRING]}]
   },
   jsonStringify: {
-    _func: ([v]) => JSON.stringify(v, null, 2),
-    _signature: [{types: [TYPE_OBJECT, TYPE_ARRAY, TYPE_ANY]}]
+    _func: ([value, replacer = null, space = 2]) => JSON.stringify(value, replacer, space),
+    _signature: [
+      { types: [TYPE_OBJECT, TYPE_ARRAY, TYPE_ANY] },  // value
+      { optional: true, types: [TYPE_NULL, TYPE_ARRAY] }, // replacer
+      { optional: true, types: [TYPE_NUMBER, TYPE_STRING] } // space
+    ]
   },
   markdown: {
     _func: ([s]) => {


### PR DESCRIPTION
Improve mapping `json()` utility function so that can take arguments.
This is done in order to render a prettified JSON output as user needs to copy and paste it.

DONE:
- allow json() to accept args
- write unit test for json() 
- update documentation about json(), qs() and jsonParse() so is clear the difference.

`json(data)` BEFORE:

<img width="861" height="225" alt="image" src="https://github.com/user-attachments/assets/647e42a0-eda8-41bf-9299-992adbce6dbc" />
<img width="854" height="565" alt="image (1)" src="https://github.com/user-attachments/assets/060a137b-2419-4e5b-a031-deff35f19fc3" />



`json(data, null, 2)` AFTER - using args:

<img width="854" height="565" alt="image (2)" src="https://github.com/user-attachments/assets/bd955b99-7f48-484d-ba34-78fee19abcd1" />

