### PR TITLE
Updating Cypress Docker container image

### DIFF
--- a/.github/actions/tests/Dockerfile
+++ b/.github/actions/tests/Dockerfile
@@ -1,15 +1,7 @@
-FROM cypress/included:8.4.1
-
-# Install Node 18
-RUN curl -fsSL https://deb.nodesource.com/setup_18.x | bash - && \
-    apt-get install -y nodejs && \
-    mv /usr/local/bin/node /usr/local/bin/node_old && \
-    ln -s /usr/bin/node /usr/local/bin/node && \
-    npm install -g npm@latest && \
-    node --version && npm --version
+FROM cypress/included:14.5.1
 
 # https://docs.cypress.io/guides/continuous-integration/introduction#Machine-requirements
-RUN apt-get update && apt-get install -y curl jq
+RUN apt-get update && apt-get install -y curl jq xauth
 # Copies your code file from your action repository to the filesystem path `/` of the container
 COPY entrypoint.sh /entrypoint.sh
 


### PR DESCRIPTION
Issue #544 https://github.com/kendraio/kendraio-app/issues/544

Updating Docker container image from `cypress/included:8.4.1` to `cypress/included:14.5.1` to use compatible version of Debian and run test smoothly.
 