### PR TITLE
feat: surface build date and add cache reset

### DIFF
--- a/src/app/components/workflow-sidenav/workflow-sidenav.component.html
+++ b/src/app/components/workflow-sidenav/workflow-sidenav.component.html
@@ -1,4 +1,8 @@
 
+    <div class="build-info" *ngIf="buildDate$ | async as buildDate">
+      Build: {{ buildDate | date:'medium' }}
+    </div>
+
     <div class="toolbar">
       <button type="button" mat-icon-button (click)="toggleExpand()" [matTooltip]="isExpanded ? 'Shrink' : 'Expand'">
         <mat-icon>{{ isExpanded ? 'arrow_right' : 'arrow_left' }}</mat-icon>
@@ -6,6 +10,9 @@
 
       <button type="button" mat-icon-button (click)="workflow.clearBlocks()" matTooltip="Clear workflow">
         <mat-icon>delete_forever</mat-icon>
+      </button>
+      <button type="button" mat-icon-button (click)="clearServiceWorkerCaches()" matTooltip="Clear cached data">
+        <mat-icon>delete_sweep</mat-icon>
       </button>
 <!--      <button type="button" mat-icon-button (click)="workflow.clearWorkflowData()" matTooltip="Clear workflow data">-->
 <!--        <app-kendraio-icon icon="fa-eraser"></app-kendraio-icon>-->

--- a/src/app/components/workflow-sidenav/workflow-sidenav.component.scss
+++ b/src/app/components/workflow-sidenav/workflow-sidenav.component.scss
@@ -5,8 +5,19 @@
   transition: transform 250ms cubic-bezier(0, 0, 0.2, 1);
 }
 
+.build-info {
+  font-size: 0.75rem;
+  color: rgba(0, 0, 0, 0.54);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  margin-bottom: 0.5rem;
+}
+
 .toolbar {
   margin-bottom: 1em;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.25rem;
 }
 
 .adapter-metadata {

--- a/src/app/components/workflow-sidenav/workflow-sidenav.component.ts
+++ b/src/app/components/workflow-sidenav/workflow-sidenav.component.ts
@@ -1,6 +1,7 @@
 import {Component, EventEmitter, HostBinding, OnInit, Output} from '@angular/core';
+import {Observable} from 'rxjs';
 import {WorkflowService} from '../../services/workflow.service';
-import {PageTitleService} from '../../services/page-title.service';
+import {BuildInfoService} from '../../services/build-info.service';
 
 @Component({
   selector: 'app-workflow-sidenav',
@@ -16,9 +17,14 @@ export class WorkflowSidenavComponent implements OnInit {
 
   isExpanded = false;
 
+  readonly buildDate$: Observable<Date | null>;
+
   constructor(
-    public readonly workflow: WorkflowService
-  ) { }
+    public readonly workflow: WorkflowService,
+    private readonly buildInfo: BuildInfoService
+  ) {
+    this.buildDate$ = this.buildInfo.buildDate$;
+  }
 
   ngOnInit() {
   }
@@ -26,6 +32,24 @@ export class WorkflowSidenavComponent implements OnInit {
   toggleExpand() {
     this.isExpanded = !this.isExpanded;
     this.width = this.isExpanded ? 800 : 500;
+  }
+
+  async clearServiceWorkerCaches(): Promise<void> {
+    if (typeof window === 'undefined') {
+      return;
+    }
+
+    if ('serviceWorker' in navigator) {
+      const registrations = await navigator.serviceWorker.getRegistrations();
+      await Promise.all(registrations.map((registration) => registration.unregister()));
+    }
+
+    if ('caches' in window) {
+      const cacheKeys = await caches.keys();
+      await Promise.all(cacheKeys.map((cacheKey) => caches.delete(cacheKey)));
+    }
+
+    window.location.reload();
   }
 
 }

--- a/src/app/services/build-info.service.ts
+++ b/src/app/services/build-info.service.ts
@@ -1,0 +1,30 @@
+import { Injectable } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { Observable, of } from 'rxjs';
+import { catchError, map, shareReplay } from 'rxjs/operators';
+
+interface NgswManifest {
+  timestamp?: number;
+}
+
+@Injectable({
+  providedIn: 'root'
+})
+export class BuildInfoService {
+  private readonly buildDateInternal$: Observable<Date | null>;
+
+  constructor(private readonly http: HttpClient) {
+    this.buildDateInternal$ = this.http.get<NgswManifest>('/ngsw.json').pipe(
+      map((manifest) => (manifest?.timestamp ? new Date(manifest.timestamp) : null)),
+      catchError((error) => {
+        console.warn('Unable to load build timestamp from ngsw.json', error);
+        return of(null);
+      }),
+      shareReplay(1)
+    );
+  }
+
+  get buildDate$(): Observable<Date | null> {
+    return this.buildDateInternal$;
+  }
+}


### PR DESCRIPTION
## Summary
- add a build info service that exposes the service worker manifest timestamp
- show the build date at the top of the workflow sidebar
- add a toolbar control to clear service worker caches and reload the app

## Testing
- npm run lint *(fails: Cannot find "lint" target for the specified project)*

------
https://chatgpt.com/codex/tasks/task_e_68de448165e88328b505906af33a4886