### PR TITLE
Fix main content width regression

### DIFF
--- a/src/app/app.component.scss
+++ b/src/app/app.component.scss
@@ -6,7 +6,6 @@
 }
 
 :host ::ng-deep mat-sidenav-container.app-container {
-  display: flex;
   flex: 1 1 auto;
   height: 100%;
   min-height: 0;


### PR DESCRIPTION
Removes flex display on app-container.
The `display:flex` on `.app-container` caused `mat-sidenav-content` to compute a narrow width.
Fixes #572