### PR TITLE
Adds Flow block configuration and data to debug errors

### DIFF
--- a/src/app/components/blocks-workflow/blocks-workflow.component.ts
+++ b/src/app/components/blocks-workflow/blocks-workflow.component.ts
@@ -1,12 +1,17 @@
-import {Component, EventEmitter, Input, OnInit, Output} from '@angular/core';
+import {Component, EventEmitter, Input, OnChanges, OnDestroy, OnInit, Output, SimpleChanges} from '@angular/core';
 import {clone} from 'lodash-es';
+import {
+  registerWorkflowDebugProvider,
+  unregisterWorkflowDebugProvider,
+  WorkflowDebugSnapshot
+} from 'src/app/services/global-error-handler.service';
 
 @Component({
   selector: 'app-blocks-workflow',
   templateUrl: './blocks-workflow.component.html',
   styleUrls: ['./blocks-workflow.component.scss']
 })
-export class BlocksWorkflowComponent implements OnInit {
+export class BlocksWorkflowComponent implements OnInit, OnChanges, OnDestroy {
 
   @Input() blocks = [];
   @Input() models = [];
@@ -14,15 +19,42 @@ export class BlocksWorkflowComponent implements OnInit {
 
   @Output() workflowComplete = new EventEmitter();
 
-  constructor() { }
+  private static instanceCounter = 0;
+  private static activityCounter = 0;
+  private readonly debugWorkflowId = `workflow-${++BlocksWorkflowComponent.instanceCounter}`;
+  private blockStates = new Map<number, { config: any; model: any }>();
+  private lastActiveBlockIndex: number | null = null;
+  private lastTargetBlockIndex: number | null = null;
+  private lastActivityTick = 0;
+  private recentActiveBlocks: Array<{ index: number; tick: number }> = [];
+
+  constructor() {
+    registerWorkflowDebugProvider(this.debugWorkflowId, () => this.createDebugSnapshot());
+  }
 
   ngOnInit() {
+  }
+
+  ngOnChanges(changes: SimpleChanges) {
+    if (changes.blocks || changes.models) {
+      this.rebuildDebugState();
+    }
+  }
+
+  ngOnDestroy() {
+    unregisterWorkflowDebugProvider(this.debugWorkflowId);
   }
 
   updateModel(modelNumber, value) {
     // console.log({ modelNumber, value });
     // console.log(this.models);
     this.models = [...this.models.slice(0, modelNumber), value, ...this.models.slice(modelNumber + 1)];
+    const emittingIndex = modelNumber - 1;
+    this.lastActiveBlockIndex = emittingIndex >= 0 ? emittingIndex : null;
+    this.lastTargetBlockIndex = modelNumber;
+    this.trackActiveBlock(this.lastActiveBlockIndex);
+    this.updateBlockSnapshot(modelNumber);
+    this.updateBlockSnapshot(this.lastActiveBlockIndex);
     // Force change
     this.blocks = [...this.blocks];
     // Output as complete workflow if final block is causing the updating
@@ -34,6 +66,55 @@ export class BlocksWorkflowComponent implements OnInit {
   runWorkflow() {
     if (this.models.length > 0) {
       this.models[0] = clone(this.models[0]);
+      this.updateBlockSnapshot(0);
+      this.lastActiveBlockIndex = 0;
+      this.lastTargetBlockIndex = 0;
+      this.trackActiveBlock(0);
     }
+  }
+
+  private rebuildDebugState() {
+    const next = new Map<number, { config: any; model: any }>();
+    this.blocks.forEach((block, index) => {
+      next.set(index, { config: block, model: this.models[index] });
+    });
+    for (let modelIndex = this.blocks.length; modelIndex < this.models.length; modelIndex++) {
+      next.set(modelIndex, { config: null, model: this.models[modelIndex] });
+    }
+    this.blockStates = next;
+  }
+
+  private updateBlockSnapshot(index: number | null) {
+    if (index === null || index < 0) {
+      return;
+    }
+    const config = index < this.blocks.length ? this.blocks[index] : null;
+    const model = this.models[index];
+    this.blockStates.set(index, { config, model });
+  }
+
+  private trackActiveBlock(index: number | null) {
+    if (index === null || index < 0) {
+      return;
+    }
+    const tick = ++BlocksWorkflowComponent.activityCounter;
+    this.lastActivityTick = tick;
+    this.recentActiveBlocks = [...this.recentActiveBlocks, { index, tick }].slice(-5);
+  }
+
+  private createDebugSnapshot(): WorkflowDebugSnapshot {
+    return {
+      workflowId: this.debugWorkflowId,
+      lastActiveBlockIndex: this.lastActiveBlockIndex,
+      lastTargetBlockIndex: this.lastTargetBlockIndex,
+      blockStates: Array.from(this.blockStates.entries()).map(([index, state]) => ({
+        index,
+        blockType: state.config && state.config.type,
+        config: state.config,
+        model: state.model
+      })),
+      recentActiveBlocks: [...this.recentActiveBlocks],
+      lastActivityTick: this.lastActivityTick
+    };
   }
 }

--- a/src/app/services/global-error-handler.service.ts
+++ b/src/app/services/global-error-handler.service.ts
@@ -3,6 +3,109 @@ import { MatLegacySnackBar as MatSnackBar } from '@angular/material/legacy-snack
 import {Subject} from 'rxjs';
 import {debounceTime, throttleTime} from 'rxjs/operators';
 
+export interface WorkflowDebugBlockState {
+  index: number;
+  blockType?: string;
+  config: any;
+  model: any;
+}
+
+export interface WorkflowDebugSnapshot {
+  workflowId: string;
+  lastActiveBlockIndex: number | null;
+  lastTargetBlockIndex: number | null;
+  blockStates: WorkflowDebugBlockState[];
+  recentActiveBlocks: Array<{ index: number; tick: number }>;
+  lastActivityTick: number;
+}
+
+type WorkflowDebugProvider = () => WorkflowDebugSnapshot;
+
+const workflowDebugProviders = new Map<string, WorkflowDebugProvider>();
+
+export function registerWorkflowDebugProvider(id: string, provider: WorkflowDebugProvider): void {
+  workflowDebugProviders.set(id, provider);
+}
+
+export function unregisterWorkflowDebugProvider(id: string): void {
+  workflowDebugProviders.delete(id);
+}
+
+export function getWorkflowDebugSnapshots(): WorkflowDebugSnapshot[] {
+  return Array.from(workflowDebugProviders.entries()).map(([id, provider]) => {
+    try {
+      const snapshot = provider();
+      if (snapshot && snapshot.workflowId) {
+        return snapshot;
+      }
+    } catch (providerError: any) {
+      console.warn('Failed to collect workflow debug snapshot', id, providerError);
+    }
+    return {
+      workflowId: id,
+      lastActiveBlockIndex: null,
+      lastTargetBlockIndex: null,
+      blockStates: [],
+      recentActiveBlocks: [],
+      lastActivityTick: 0
+    };
+  });
+}
+
+export function logWorkflowDebugSnapshots(label = 'Workflow debug state'): void {
+  const snapshots = getWorkflowDebugSnapshots();
+  if (snapshots.length === 0) {
+    return;
+  }
+  console.info(label, snapshots);
+  logRecentActivityEntries(snapshots);
+}
+
+function logRecentActivityEntries(snapshots: WorkflowDebugSnapshot[]): void {
+  const entries = snapshots.flatMap(snapshot =>
+    snapshot.recentActiveBlocks.map(block => ({ snapshot, block }))
+  );
+
+  if (entries.length === 0) {
+    return;
+  }
+
+  entries.sort((a, b) => a.block.tick - b.block.tick);
+  const firstEntries = entries.slice(0, Math.min(5, entries.length));
+  const lastEntries = entries.length > 5 ? entries.slice(-5) : [];
+
+  const logEntryBatch = (batchLabel: string, batch: typeof entries) => {
+    batch.forEach((entry, idx) => {
+      const { snapshot, block } = entry;
+      const state = snapshot.blockStates.find(blockState => blockState.index === block.index);
+      const blockLabel = state?.blockType || '(unknown)';
+      const markers: string[] = [];
+      if (block.index === snapshot.lastActiveBlockIndex) {
+        markers.push('active');
+      }
+      if (block.index === snapshot.lastTargetBlockIndex) {
+        markers.push('target');
+      }
+      const markerLabel = markers.length ? ` [${markers.join(', ')}]` : '';
+      console.info(`[${batchLabel} #${idx + 1}] Workflow ${snapshot.workflowId} block ${block.index}${markerLabel} type=${blockLabel}`);
+      console.dir({ config: state?.config, data: state?.model }, { depth: 1 });
+    });
+  };
+
+  logEntryBatch('First', firstEntries);
+  if (lastEntries.length > 0) {
+    logEntryBatch('Last', lastEntries);
+  }
+}
+
+
+function truncate(value: string, maxLength = 200): string {
+  if (value.length <= maxLength) {
+    return value;
+  }
+  return `${value.slice(0, maxLength)}…`;
+}
+
 @Injectable()
 export class GlobalErrorHandlerService implements ErrorHandler {
 
@@ -23,6 +126,7 @@ export class GlobalErrorHandlerService implements ErrorHandler {
 
   handleError(error: any): void {
     console.error(error);
+    logWorkflowDebugSnapshots('Workflow state at error');
     this.error$.next(error);
   }
 }


### PR DESCRIPTION
Currently when there a Block in a Flow has an error, the error information shown in the console lacks important context about which Block causes the error (see issue #582). 
This Pull Request adds recent Block configuration and data inputs to the browser console logs to help solve this problem.