### PR TITLE
Material style fixes for develop branch

### DIFF
--- a/src/app/_shared/ui-form/ui-form.module.ts
+++ b/src/app/_shared/ui-form/ui-form.module.ts
@@ -11,6 +11,7 @@ import {NgSelectModule} from '@ng-select/ng-select';
 import {FormlyMatDatepickerModule} from '@ngx-formly/material/datepicker';
 
 import {MatButtonToggleModule} from '@angular/material/button-toggle';
+import {MatButtonModule} from '@angular/material/button';
 import {MatIconModule} from '@angular/material/icon';
 import {FormlyMaterialModule} from '@ngx-formly/material';
 import {NgxMaterialTimepickerModule} from 'ngx-material-timepicker';
@@ -33,6 +34,7 @@ import {MatRadioModule} from '@angular/material/radio';
     FlexLayoutModule,
     NgSelectModule,
     FormlyMaterialModule,
+    MatButtonModule,
     MatButtonToggleModule,
     MatIconModule,
     FormlyMatDatepickerModule,
@@ -46,6 +48,7 @@ import {MatRadioModule} from '@angular/material/radio';
   exports: [
     FormsModule,
     ReactiveFormsModule,
+    MatButtonModule,
     MatButtonToggleModule,
     MatIconModule,
     NgSelectModule,

--- a/src/styles/main.scss
+++ b/src/styles/main.scss
@@ -256,6 +256,10 @@ formly-array-type {
   align-self: flex-start;
 }
 
+.mat-mdc-button-base {
+  padding: 0.25rem 0.5rem;
+}
+
 // Fix for cut-off Formly Material label
 .mdc-text-field--filled::before{
   content: "" !important;

--- a/src/styles/main.scss
+++ b/src/styles/main.scss
@@ -250,7 +250,10 @@ formly-array-type {
     .mat-mdc-card {
       margin-right: 16px;
     }
+}
 
+.mat-mdc-card > .mat-mdc-button-base {
+  align-self: flex-start;
 }
 
 // Fix for cut-off Formly Material label


### PR DESCRIPTION
3 fixes (and 3 commits) were made correct visual defects with the Material button, including it's use in the Form block:

- Provides the Material button reference to our Formly wrapper, so it actually can load.
- Add missing padding to MatButtonBase
- Stops Material buttons in Material cards from using all width

With the style fixes, we get:
<img width="1238" height="1126" alt="image" src="https://github.com/user-attachments/assets/142ac2ac-b798-46be-8c83-cd117929fbd3" />

Which is very close to main branch (especially considering that it is using the new Material library, as part of the Angular upgrade):
<img width="1238" height="1131" alt="image" src="https://github.com/user-attachments/assets/9fac3e20-e45a-4275-b690-92301dce1ab0" />

It is much better that the current develop branch state:
<img width="1238" height="1126" alt="image" src="https://github.com/user-attachments/assets/69a2cc37-7437-4f91-afa4-41f5f1c92762" />

Each of these 3 [use this Flow configuration](https://app.kendra.io/workflow-builder?data=NobwRALgngDgpmAXGAZgewE4FswBpICWEANgsgKowAmAhhHAAQCiAbnAHYR5jE0BGcYkjCVa9Zm07cAVgGc07AMoBjABZwsNJOGjxhaPtLjKu%20GBjTwMEAnFnbCygNZwIsgPqb2NAOZwMDrpkYDQYGDRQ3DYkwQAqBM6usgwAsjTefgH4RBr2iDqwwQZGJtzmlv42doGFNXrIshAYBOw%203BwArjiIwGCxAJIAwgDSTLGKYAC6AL6zc-gdBCrqmtrT%20HzEaM6DaFhYHFzIYNOTQA) , with the Form block open in the right-hand sidebar for easy visual comparison.