### PR TITLE
Connect page Launch buttons

### DIFF
--- a/docs/adapters/creating.rst
+++ b/docs/adapters/creating.rst
@@ -5,3 +5,30 @@ An adapter is a set of configuration files that work with the building blocks
 of functionality within the Kendraio App to provide features and integrations
 with third-party services. Essentially, an adapter is just a set of JSON configuration
 files.
+
+Connect Flows
+-------------
+
+The App's Connect page lists Flows tagged with ``connect``. A Connect Flow may
+also point to the dashboard or starting Flow for the same integration by adding
+a ``start:`` prefixed link, as illustrated below. When the tag is present, the
+Connect page shows a Launch button for that Flow; when it is missing, no Launch
+button is shown.
+
+Use an adapter and Flow route, not a full external URL:
+
+.. code-block:: json
+
+    {
+      "title": "Fireflies Connect",
+      "id": "connect",
+      "adapterName": "fireflies",
+      "tags": [
+        "connect",
+        "start:fireflies/listMeetings"
+      ]
+    }
+
+The ``start:fireflies/listMeetings`` tag links the Connect Flow to
+``fireflies/listMeetings`` to help users visit after connecting / 
+authentication setup.

--- a/playwright/connect-launch.spec.ts
+++ b/playwright/connect-launch.spec.ts
@@ -1,0 +1,134 @@
+import { expect, test } from '@playwright/test';
+import { appUrl, loadFlowCode, mockAdapterConfig, mockFonts } from './support';
+
+const connectFlows = [
+  {
+    id: 'connectA',
+    workflowId: 'connectA',
+    title: 'Connect flow with dashboard',
+    tags: ['connect', 'start:/core/dashboard'],
+    adapterName: 'testAdapter',
+  },
+  {
+    id: 'connectB',
+    workflowId: 'connectB',
+    title: 'Connect flow without dashboard',
+    tags: ['connect'],
+    adapterName: 'testAdapter',
+  },
+];
+
+const startRouteGetter =
+  'replace(replace(not_null(data.tags[?starts_with(@, `start:`)] | [0], ``), `start:/`, ``), `start:`, ``)';
+const hasStartRouteGetter =
+  `length(split(${startRouteGetter}, \`/\`)) == \`2\` && ` +
+  `split(${startRouteGetter}, \`/\`)[0] != \`\` && ` +
+  `split(${startRouteGetter}, \`/\`)[1] != \`\``;
+const flowCentricRows = [
+  {
+    title: 'Flow renderer row with dashboard',
+    tags: ['connect', 'start:/core/dashboard'],
+  },
+  {
+    title: 'Flow renderer row without dashboard',
+    tags: ['connect'],
+  },
+];
+const flowCentricGridBlocks = [
+  {
+    type: 'mapping',
+    mapping: `\`${JSON.stringify(flowCentricRows)}\``,
+  },
+  {
+    type: 'grid',
+    columnDefs: [
+      {
+        headerName: 'Title',
+        field: 'title',
+      },
+      {
+        headerName: 'Launch',
+        cellRenderer: 'workflowRenderer',
+        cellRendererParams: {
+          blocks: [
+            {
+              type: 'switch',
+              valueGetter: hasStartRouteGetter,
+              cases: [
+                {
+                  value: true,
+                  blocks: [
+                    {
+                      type: 'link-action',
+                      label: 'Launch',
+                      adapterNameGetter: `split(${startRouteGetter}, \`/\`)[0]`,
+                      workflowIdGetter: `split(${startRouteGetter}, \`/\`)[1]`,
+                    },
+                  ],
+                },
+              ],
+              default: {
+                blocks: [],
+              },
+            },
+          ],
+        },
+      },
+    ],
+  },
+];
+
+test.describe('Connect Flow launch links', () => {
+  test('shows a Launch link from the start tag and leaves untagged rows empty', async ({ page }) => {
+    await mockAdapterConfig(page);
+    await mockFonts(page);
+    await page.route('**/api/tag/connect', route =>
+      route.fulfill({
+        contentType: 'application/json',
+        body: JSON.stringify(connectFlows),
+      })
+    );
+    await page.route('**/api/core/dashboard', route =>
+      route.fulfill({
+        contentType: 'application/json',
+        body: JSON.stringify({
+          title: 'Tagged Dashboard Flow',
+          tags: [],
+          blocks: [
+            {
+              type: 'message',
+              title: 'Tagged Dashboard Flow',
+            },
+          ],
+        }),
+      })
+    );
+
+    await page.goto(`${appUrl}/connect`);
+    await expect(page.getByText('Connect flow with dashboard')).toBeVisible();
+    await expect(page.getByText('Connect flow without dashboard')).toBeVisible();
+
+    const launchLinks = page.getByRole('link', { name: 'Launch' });
+    await expect(launchLinks).toHaveCount(1);
+    await expect(launchLinks.first()).toHaveAttribute('href', /\/core\/dashboard$/);
+
+    await launchLinks.first().click();
+
+    await expect(page).toHaveURL(/\/core\/dashboard$/);
+    await expect(page.getByRole('heading', { name: 'Tagged Dashboard Flow' })).toBeVisible();
+  });
+
+  test('supports a Flow-centric Launch column with workflowRenderer and link-action', async ({ page }) => {
+    await mockAdapterConfig(page);
+    await mockFonts(page);
+
+    await loadFlowCode(page, flowCentricGridBlocks);
+
+    await expect(page.getByText('Flow renderer row with dashboard')).toBeVisible();
+    await expect(page.getByText('Flow renderer row without dashboard')).toBeVisible();
+
+    const launchLinks = page.locator('app-grid-block').getByRole('link', { name: 'Launch' });
+    await expect(launchLinks).toHaveCount(1);
+    await expect(launchLinks.first()).toHaveAttribute('href', /\/core\/dashboard$/);
+  });
+});

--- a/playwright/issue-611-button-colour-visibility.spec.ts
+++ b/playwright/issue-611-button-colour-visibility.spec.ts
@@ -1,0 +1,353 @@
+import { expect, test, type Locator } from '@playwright/test';
+import { dirname, join } from 'path';
+import { mkdirSync, readFileSync, writeFileSync } from 'fs';
+import { loadFlowCode, mockCommonRequests } from './support';
+
+const screenshotPath = process.env.PLAYWRIGHT_BUTTON_LAB_SCREENSHOT ||
+  join(process.cwd(), 'test-results', 'issue-611-flow-button-sources.png');
+const dialogScreenshotPath = screenshotPath.replace(/\.png$/, '-dialog.png');
+const coloursPath = screenshotPath.replace(/\.png$/, '-colours.json');
+const whiteColoursPath = screenshotPath.replace(/\.png$/, '-white-colours.json');
+const whiteBackground = 'rgb(255, 255, 255)';
+const expectedWhiteColourKeys = [];
+
+const flowLabStyles = `
+  html,
+  body {
+    height: auto !important;
+    overflow: auto !important;
+  }
+
+  app-root,
+  mat-sidenav-content,
+  .mat-drawer-content {
+    min-height: 100vh;
+    overflow: auto !important;
+  }
+
+  app-blocks-workflow {
+    display: block;
+    max-width: 1160px;
+    padding: 24px;
+  }
+
+  app-template-block.block-wrapper,
+  app-actions-block.block-wrapper,
+  app-link-action.block-wrapper,
+  app-form-block.block-wrapper,
+  app-grid-block.block-wrapper {
+    display: block;
+    margin-bottom: 22px;
+  }
+
+  .issue-611-section {
+    border-top: 1px solid rgba(0, 0, 0, 0.12);
+    padding-top: 16px;
+  }
+
+  .issue-611-section:first-child {
+    border-top: 0;
+    padding-top: 0;
+  }
+
+  .issue-611-section h1,
+  .issue-611-section h2 {
+    margin: 0 0 8px;
+  }
+
+  .issue-611-section p {
+    margin: 0 0 12px;
+  }
+
+  app-actions-block .actions-button,
+  app-link-action a {
+    margin: 0 10px 10px 0;
+  }
+
+  ag-grid-angular {
+    min-height: 116px;
+  }
+`;
+
+async function renderedColours(locator: Locator) {
+  return locator.evaluate(element => {
+    const isTransparent = (value: string) =>
+      value === 'transparent' ||
+      value === 'rgba(0, 0, 0, 0)' ||
+      value === 'rgba(0,0,0,0)';
+    const style = window.getComputedStyle(element);
+    let effectiveBackgroundElement: Element | null = element;
+    let effectiveBackgroundColor = style.backgroundColor;
+
+    while (effectiveBackgroundElement && isTransparent(effectiveBackgroundColor)) {
+      effectiveBackgroundElement = effectiveBackgroundElement.parentElement;
+      effectiveBackgroundColor = effectiveBackgroundElement
+        ? window.getComputedStyle(effectiveBackgroundElement).backgroundColor
+        : effectiveBackgroundColor;
+    }
+
+    return {
+      background_color: style.backgroundColor,
+      text_color: style.color,
+      border_color: style.borderColor,
+      effective_background_color: effectiveBackgroundColor,
+      opacity: style.opacity,
+    };
+  });
+}
+
+test.describe('Issue 611 button colour visibility', () => {
+  test.describe.configure({ mode: 'serial' });
+
+  test.use({ viewport: { width: 1440, height: 1200 } });
+
+  test.beforeEach(async ({ page }) => {
+    await mockCommonRequests(page);
+  });
+
+  test('shows current Flow-rendered button sources for visual inspection', async ({ page }, testInfo) => {
+    const waitMs = Number(process.env.PLAYWRIGHT_BUTTON_LAB_WAIT_MS || 0);
+    test.setTimeout(35_000 + waitMs);
+
+    await loadFlowCode(page, [
+      {
+        type: 'template',
+        renderToScreen: true,
+        template: `
+          <section class="issue-611-section">
+            <h1>Issue 611 Flow button sources</h1>
+            <p>Template block anchor link: <a href="/connect">Open Connect</a></p>
+          </section>
+        `,
+      },
+      {
+        type: 'template',
+        renderToScreen: true,
+        template: `
+          <section class="issue-611-section">
+            <h2>Actions block buttons</h2>
+            <p>Flat action buttons with no colour, primary, accent, warn, link, disabled, and a dialog trigger.</p>
+          </section>
+        `,
+      },
+      {
+        type: 'actions',
+        buttons: [
+          { label: 'Actions default flat', id: 'issue-611-actions-default', blocks: [] },
+          { label: 'Actions primary flat', id: 'issue-611-actions-primary', color: 'primary', blocks: [] },
+          { label: 'Actions accent flat', id: 'issue-611-actions-accent', color: 'accent', blocks: [] },
+          { label: 'Actions warn flat', id: 'issue-611-actions-warn', color: 'warn', blocks: [] },
+          { label: 'Actions link text', id: 'issue-611-actions-link', color: 'link', blocks: [] },
+          {
+            label: 'Actions disabled flat',
+            id: 'issue-611-actions-disabled',
+            enabledGetter: '`false`',
+            blocks: [],
+          },
+          {
+            label: 'Open dialog block',
+            id: 'issue-611-open-dialog',
+            blocks: [
+              {
+                type: 'dialog',
+                blocks: [
+                  {
+                    type: 'template',
+                    renderToScreen: true,
+                    template: `
+                      <section class="issue-611-section">
+                        <h2>Dialog block</h2>
+                        <p>This dialog is opened by a Flow action and contains a form block button.</p>
+                      </section>
+                    `,
+                  },
+                  {
+                    type: 'form',
+                    label: 'Dialog form submit',
+                    jsonSchema: {
+                      type: 'object',
+                      properties: {
+                        note: {
+                          type: 'string',
+                          title: 'Dialog note',
+                        },
+                      },
+                    },
+                    uiSchema: {},
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      },
+      {
+        type: 'template',
+        renderToScreen: true,
+        template: `
+          <section class="issue-611-section">
+            <h2>Link Action block</h2>
+            <p>The Link Action block renders a flat link to another Flow.</p>
+          </section>
+        `,
+      },
+      {
+        type: 'link-action',
+        label: 'Link Action default flat',
+        adapterName: 'core',
+        workflowId: 'dashboard',
+      },
+      {
+        type: 'template',
+        renderToScreen: true,
+        template: `
+          <section class="issue-611-section">
+            <h2>Form block button</h2>
+            <p>The Form block renders a primary submit button.</p>
+          </section>
+        `,
+      },
+      {
+        type: 'form',
+        label: 'Form block submit',
+        jsonSchema: {
+          type: 'object',
+          properties: {
+            title: {
+              type: 'string',
+              title: 'Title',
+            },
+          },
+        },
+        uiSchema: {},
+      },
+      {
+        type: 'template',
+        renderToScreen: true,
+        template: `
+          <section class="issue-611-section">
+            <h2>Grid cellRendererParams action buttons</h2>
+            <p>Each row renders an Actions block inside a workflowRenderer cell.</p>
+          </section>
+        `,
+      },
+      {
+        type: 'mapping',
+        mapping: '[{ name: `Example row`, status: `Ready` }]',
+      },
+      {
+        type: 'grid',
+        gridOptions: {
+          rowHeight: 58,
+          suppressCellFocus: true,
+        },
+        sizeColumnsToFit: false,
+        columnDefs: [
+          {
+            headerName: 'Name',
+            field: 'name',
+            width: 180,
+          },
+          {
+            headerName: 'Status',
+            field: 'status',
+            width: 140,
+          },
+          {
+            headerName: 'Per-row actions',
+            width: 560,
+            cellRenderer: 'workflowRenderer',
+            cellRendererParams: {
+              blocks: [
+                {
+                  type: 'actions',
+                  buttons: [
+                    { label: 'Grid default flat', id: 'issue-611-grid-default', blocks: [] },
+                    { label: 'Grid primary flat', id: 'issue-611-grid-primary', color: 'primary', blocks: [] },
+                    { label: 'Grid warn flat', id: 'issue-611-grid-warn', color: 'warn', blocks: [] },
+                  ],
+                },
+              ],
+            },
+          },
+        ],
+      },
+    ]);
+
+    await page.addStyleTag({ content: flowLabStyles });
+
+    await expect(page.getByRole('button', { name: 'Actions default flat' })).toBeVisible();
+    await expect(page.getByRole('link', { name: 'Link Action default flat' })).toBeVisible();
+    await expect(page.getByRole('button', { name: 'Form block submit' })).toBeVisible();
+    await expect(page.getByRole('link', { name: 'Open Connect' })).toBeVisible();
+    await expect(page.getByRole('button', { name: 'Grid default flat' })).toBeVisible();
+
+    mkdirSync(dirname(screenshotPath), { recursive: true });
+    await page.screenshot({ path: screenshotPath, fullPage: true });
+    await testInfo.attach('issue-611-flow-button-sources', {
+      path: screenshotPath,
+      contentType: 'image/png',
+    });
+
+    const colours = {
+      template_anchor_link: await renderedColours(page.getByRole('link', { name: 'Open Connect' })),
+      actions_default_flat: await renderedColours(page.locator('#issue-611-actions-default')),
+      actions_primary_flat: await renderedColours(page.locator('#issue-611-actions-primary')),
+      actions_accent_flat: await renderedColours(page.locator('#issue-611-actions-accent')),
+      actions_warn_flat: await renderedColours(page.locator('#issue-611-actions-warn')),
+      actions_link_text: await renderedColours(page.locator('#issue-611-actions-link')),
+      actions_disabled_flat: await renderedColours(page.locator('#issue-611-actions-disabled')),
+      open_dialog_block: await renderedColours(page.locator('#issue-611-open-dialog')),
+      link_action_default_flat: await renderedColours(page.locator('app-link-action a')),
+      form_block_submit: await renderedColours(page.getByRole('button', { name: 'Form block submit' })),
+      grid_default_flat: await renderedColours(page.locator('#issue-611-grid-default')),
+      grid_primary_flat: await renderedColours(page.locator('#issue-611-grid-primary')),
+      grid_warn_flat: await renderedColours(page.locator('#issue-611-grid-warn')),
+    };
+
+    await page.getByRole('button', { name: 'Open dialog block' }).click();
+    const dialog = page.locator('mat-dialog-container').first();
+    await expect(dialog).toBeVisible();
+    await expect(dialog.getByRole('button', { name: 'Dialog form submit' })).toBeVisible();
+    await dialog.screenshot({ path: dialogScreenshotPath });
+    await testInfo.attach('issue-611-flow-button-sources-dialog', {
+      path: dialogScreenshotPath,
+      contentType: 'image/png',
+    });
+
+    const coloursWithDialog = {
+      ...colours,
+      dialog_form_submit: await renderedColours(dialog.getByRole('button', { name: 'Dialog form submit' })),
+    };
+    const coloursJson = JSON.stringify(coloursWithDialog, null, 2);
+    writeFileSync(coloursPath, `${coloursJson}\n`);
+    console.log(`issue_611_flow_button_colours = ${coloursJson}`);
+    await testInfo.attach('issue-611-flow-button-colours', {
+      path: coloursPath,
+      contentType: 'application/json',
+    });
+
+    if (waitMs > 0) {
+      await page.waitForTimeout(waitMs);
+    }
+  });
+
+  test('extracts the current white Flow-rendered button sources from the colour JSON', async ({}, testInfo) => {
+    const colours = JSON.parse(readFileSync(coloursPath, 'utf8'));
+    const whiteColours = Object.fromEntries(
+      Object.entries(colours).filter(([, value]: [string, any]) =>
+        value.background_color === whiteBackground
+      )
+    );
+    const whiteColoursJson = JSON.stringify(whiteColours, null, 2);
+
+    writeFileSync(whiteColoursPath, `${whiteColoursJson}\n`);
+    console.log(`issue_611_white_flow_button_colours = ${whiteColoursJson}`);
+
+    expect(Object.keys(whiteColours).sort()).toEqual([...expectedWhiteColourKeys].sort());
+    await testInfo.attach('issue-611-white-flow-button-colours', {
+      path: whiteColoursPath,
+      contentType: 'application/json',
+    });
+  });
+});

--- a/src/app/pages/connect/connect.component.ts
+++ b/src/app/pages/connect/connect.component.ts
@@ -21,6 +21,40 @@ export class ConnectComponent implements OnInit {
         cellRenderer: 'connectionStatusRenderer'
       },
       {
+        headerName: 'Launch',
+        cellRenderer: 'workflowRenderer',
+        width: 120,
+        cellRendererParams: {
+          blocks: [
+            {
+              type: 'switch',
+              valueGetter:
+                'length(split(replace(replace(not_null(data.tags[?starts_with(@, `start:`)] | [0], ``), `start:/`, ``), `start:`, ``), `/`)) == `2` && ' +
+                'split(replace(replace(not_null(data.tags[?starts_with(@, `start:`)] | [0], ``), `start:/`, ``), `start:`, ``), `/`)[0] != `` && ' +
+                'split(replace(replace(not_null(data.tags[?starts_with(@, `start:`)] | [0], ``), `start:/`, ``), `start:`, ``), `/`)[1] != ``',
+              cases: [
+                {
+                  value: true,
+                  blocks: [
+                    {
+                      type: 'link-action',
+                      label: 'Launch',
+                      adapterNameGetter:
+                        'split(replace(replace(not_null(data.tags[?starts_with(@, `start:`)] | [0], ``), `start:/`, ``), `start:`, ``), `/`)[0]',
+                      workflowIdGetter:
+                        'split(replace(replace(not_null(data.tags[?starts_with(@, `start:`)] | [0], ``), `start:/`, ``), `start:`, ``), `/`)[1]'
+                    }
+                  ]
+                }
+              ],
+              default: {
+                blocks: []
+              }
+            }
+          ]
+        }
+      },
+      {
         'cellRenderer': 'workflowRenderer',
         'cellRendererParams': {
           'blocks': [

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -36,6 +36,23 @@ $kendraio-app-theme: mat.m2-define-light-theme((
 
 
 // Global style, not part of the custom theme.
+$kendraio-app-default-button-background: mat.m2-get-color-from-palette($kendraio-app-primary);
+$kendraio-app-default-button-foreground: mat.m2-get-color-from-palette($kendraio-app-primary, default-contrast);
+
+.mat-mdc-unelevated-button:not(.mat-primary):not(.mat-accent):not(.mat-warn):not(:disabled):not(.mat-mdc-button-disabled):not(.mdc-button--disabled) {
+  --mdc-filled-button-container-color: #{$kendraio-app-default-button-background};
+  --mdc-filled-button-label-text-color: #{$kendraio-app-default-button-foreground};
+  --mat-filled-button-state-layer-color: #{$kendraio-app-default-button-foreground};
+  --mat-filled-button-ripple-color: #{rgba($kendraio-app-default-button-foreground, 0.1)};
+}
+
+.mat-mdc-raised-button:not(.mat-primary):not(.mat-accent):not(.mat-warn):not(:disabled):not(.mat-mdc-button-disabled):not(.mdc-button--disabled) {
+  --mdc-protected-button-container-color: #{$kendraio-app-default-button-background};
+  --mdc-protected-button-label-text-color: #{$kendraio-app-default-button-foreground};
+  --mat-protected-button-state-layer-color: #{$kendraio-app-default-button-foreground};
+  --mat-protected-button-ripple-color: #{rgba($kendraio-app-default-button-foreground, 0.1)};
+}
+
 html, body { height: 100%; overflow: hidden; }
 body { margin: 0; font-family: Roboto, "Helvetica Neue", sans-serif; }
 


### PR DESCRIPTION
Adds Launch buttons to the Connect page for Connect Flows with a valid `start:<adapter>/<flow>` tag.

Adds adapter documentation and Playwright coverage for tagged and untagged Connect Flows.

Covered by issue #589 which it resolves.